### PR TITLE
[qt4] Don't use extendend QStringList::sort

### DIFF
--- a/src/MimeCategory.cpp
+++ b/src/MimeCategory.cpp
@@ -123,7 +123,11 @@ QStringList MimeCategory::humanReadablePatternList( Qt::CaseSensitivity caseSens
 
     result = humanReadableSuffixList( result );
     result << humanReadablePatternList( _patternList, caseSensitivity );
+#if (QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 ))
+    result.sort();
+#else
     result.sort( caseSensitivity );
+#endif
 
     return result;
 }


### PR DESCRIPTION
Qt4 didn't yet have a QStringList::sort(CaseSensitivity&)
member.  This is just for visual feedback, so ignore it, and
sort with defaults.

Signed-off-by: Michael Matz <matz@suse.de>