### PR TITLE
[qt4] Adjust empty TARGET in *.pro

### DIFF
--- a/doc/doc.pro
+++ b/doc/doc.pro
@@ -1,7 +1,7 @@
 # qmake .pro file for qdirstat/doc
 
 TEMPLATE   = app
-TARGET     =
+TARGET     = $(nothing)
 doc.files  = *.txt ../*.md ../LICENSE
 
 # Ubuntu / Debian pkg doc path

--- a/scripts/scripts.pro
+++ b/scripts/scripts.pro
@@ -1,7 +1,7 @@
 # qmake .pro file for qdirstat/scripts
 
 TEMPLATE       = app
-TARGET         =
+TARGET         = $(nothing)
 QMAKE_STRIP    = /bin/true # prevent stripping the script(s)
 
 scripts.files  = qdirstat-cache-writer


### PR DESCRIPTION
The Qt4 qmake doesn't like an really empty TARGET specification
in *.pro.  It replaces it by the name of the containing subdir,
hence a make in e.g. 'scripts/' tries to make the executable
'scripts', of course without defined SOURCES that fails.

Trick qmake by making it look like TARGET is not empty, when
in reality it will be by using a not-defined make variable.

Signed-off-by: Michael Matz <matz@suse.de>