### PR TITLE
DirTreeView::closeAllExcept(): add scrollTo()

### DIFF
--- a/src/DirTreeView.cpp
+++ b/src/DirTreeView.cpp
@@ -143,5 +143,6 @@ void DirTreeView::closeAllExcept( const QModelIndex & branch )
 	// logDebug() << "Closing " << index << endl;
 	collapse( index );
     }
+    scrollTo( currentIndex() );
 }
 


### PR DESCRIPTION
closeAllExcept() may get called after currentChanged(), make sure
current item is visible after collapsing entries