### PR TITLE
treeview: Scroll to current item if collapsing

### DIFF
--- a/src/DirTreeView.cpp
+++ b/src/DirTreeView.cpp
@@ -143,5 +143,6 @@ void DirTreeView::closeAllExcept( const QModelIndex & branch )
 	// logDebug() << "Closing " << index << endl;
 	collapse( index );
     }
+    scrollTo( currentIndex() );
 }
 


### PR DESCRIPTION
When collapsing some branches the current item might implicitely
scroll out of view.  When clicking in the tree map the current item
is changed first, then other branches are collapsed, so the current
item might not end up being displayed.  Simply scroll again to
the current item after collapsing.

Signed-off-by: Michael Matz <matz@suse.de>