### PR TITLE
Fix compilation failure with qt4 after bf8655

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -266,6 +266,12 @@ static void qt_logger( QtMsgType msgType,
         else
             abort();
     }
+
+    if ( msgType == QtWarningMsg && ((QString) msg).contains( "cannot connect to X server" ) )
+    {
+        fprintf( stderr, "WARNING: %s\n", qPrintable( msg ) );
+        exit( 1 );
+    }
 }
 
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -261,7 +261,7 @@ static void qt_logger( QtMsgType msgType,
     {
         fprintf( stderr, "FATAL: %s\n", qPrintable( msg ) );
 
-        if ( msg.contains( "Could not connect to display" ) )
+        if ( ((QString) msg).contains( "Could not connect to display" ) )
             exit( 1 );
         else
             abort();


### PR DESCRIPTION
Failed because qt4 uses char, not QString for the message. I've also added the qt4 message for being unable to connect to the display.