### PR TITLE
Added option to change the splitter orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ _Main window screenshot - notice the multi-selection in the tree and the treemap
 (https://raw.githubusercontent.com/shundhammer/qdirstat/master/screenshots/QDirStat-column-config.png)
 
 [<img src="https://github.com/shundhammer/qdirstat/blob/master/screenshots/QDirStat-locating-file-types.png" height="337">]
-(https://github.com/shundhammer/qdirstat/blob/master/screenshots/QDirStat-locating-file-types.png)
+(https://raw.githubusercontent.com/shundhammer/qdirstat/master/screenshots/QDirStat-locating-file-types.png)
 
 
 [<img src="https://github.com/shundhammer/qdirstat/blob/master/screenshots/QDirStat-cleanup-config.png" height="245">]

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -37,7 +37,7 @@ _Menu View -> File Type Statistics..._
 
 _Results after clicking on the "Locate" button in the "File Type Statistics" window._
 
-![Locating FilesWindow]
+![Locating Files]
 (https://github.com/shundhammer/qdirstat/blob/master/screenshots/QDirStat-locating-file-types.png)
 
 _Locating files with a specific extension. That branch is automatically opened

--- a/src/FileTypeStatsWindow.cpp
+++ b/src/FileTypeStatsWindow.cpp
@@ -260,7 +260,7 @@ void FileTypeStatsWindow::locateCurrentFileType()
         logWarning() << "Can't locate NO_SUFFIX" << endl;
 
         if ( _locateFilesWindow )
-            _locateFilesWindow->deleteLater();
+            _locateFilesWindow->hide();
 
         return;
     }
@@ -286,6 +286,7 @@ void FileTypeStatsWindow::locateCurrentFileType()
     }
     else // Reusing existing window
     {
+        _locateFilesWindow->show();
         _locateFilesWindow->raise();
     }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -152,6 +152,7 @@ MainWindow::MainWindow():
 
     if ( ! _ui->actionShowTreemap->isChecked() )
 	_ui->treemapView->disable();
+    //actionTreemapAsSidePanel ???
 
     toggleVerboseSelection();
     updateActions();
@@ -238,7 +239,9 @@ void MainWindow::connectActions()
     // "Treemap" menu
 
     connect( _ui->actionShowTreemap, SIGNAL( toggled( bool )   ),
-	     this,		     SLOT  ( showTreemapView() ) );
+         this,		     SLOT  ( showTreemapView() ) );
+    connect( _ui->actionTreemapAsSidePanel, SIGNAL( toggled( bool )   ),
+         this,		     SLOT  ( treemapAsSidePanel() ) );
 
     CONNECT_ACTION( _ui->actionTreemapZoomIn,	 _ui->treemapView, zoomIn()	    );
     CONNECT_ACTION( _ui->actionTreemapZoomOut,	 _ui->treemapView, zoomOut()	    );
@@ -302,7 +305,7 @@ void MainWindow::updateActions()
     _ui->actionReadExcludedDirectory->setEnabled      ( oneDirSelected && sel->isExcluded()   );
 
     bool showingTreemap = _ui->treemapView->isVisible();
-
+    _ui->actionTreemapAsSidePanel->setEnabled( showingTreemap );
     _ui->actionTreemapZoomIn->setEnabled   ( showingTreemap && _ui->treemapView->canZoomIn() );
     _ui->actionTreemapZoomOut->setEnabled  ( showingTreemap && _ui->treemapView->canZoomOut() );
     _ui->actionResetTreemapZoom->setEnabled( showingTreemap && _ui->treemapView->canZoomOut() );
@@ -317,6 +320,7 @@ void MainWindow::readSettings()
 
     _statusBarTimeout	 = settings.value( "StatusBarTimeoutMillisec", 3000 ).toInt();
     bool   showTreemap	 = settings.value( "ShowTreemap"	     , true ).toBool();
+    bool   treemapOnSide = settings.value( "TreemapOnSide"	     , true ).toBool();
     QPoint winPos	 = settings.value( "WindowPos"		     , QPoint( -99, -99 ) ).toPoint();
     QSize  winSize	 = settings.value( "WindowSize"		     , QSize (	 0,   0 ) ).toSize();
     _verboseSelection	 = settings.value( "VerboseSelection"	     , false ).toBool();
@@ -324,6 +328,9 @@ void MainWindow::readSettings()
     settings.endGroup();
 
     _ui->actionShowTreemap->setChecked( showTreemap );
+    _ui->actionTreemapAsSidePanel->setChecked( treemapOnSide );
+    treemapAsSidePanel();
+
     _ui->actionVerboseSelection->setChecked( _verboseSelection );
 
     if ( winSize.height() > 100 && winSize.width() > 100 )
@@ -343,6 +350,8 @@ void MainWindow::writeSettings()
 
     settings.setValue( "StatusBarTimeoutMillisec", _statusBarTimeout );
     settings.setValue( "ShowTreemap"		 , _ui->actionShowTreemap->isChecked() );
+    settings.setValue( "TreemapOnSide"		 , _ui->actionTreemapAsSidePanel->isChecked() );
+
     settings.setValue( "WindowPos"		 , pos()  );
     settings.setValue( "WindowSize"		 , size() );
     settings.setValue( "VerboseSelection"	 , _verboseSelection );
@@ -359,6 +368,13 @@ void MainWindow::showTreemapView()
 	_ui->treemapView->disable();
 }
 
+void MainWindow::treemapAsSidePanel()
+{
+    if ( _ui->actionTreemapAsSidePanel->isChecked() )
+        _ui->mainWinSplitter->setOrientation(Qt::Horizontal);
+    else
+        _ui->mainWinSplitter->setOrientation(Qt::Vertical);
+}
 
 void MainWindow::closeEvent( QCloseEvent *event )
 {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -217,7 +217,9 @@ void MainWindow::connectActions()
 
     mapTreeExpandAction( _ui->actionCloseAllTreeLevels, 0 );
 
-    CONNECT_ACTION( _ui->actionFileTypeStats,	   this, openFileTypeStats() );
+    CONNECT_ACTION( _ui->actionFileTypeStats,	   this, toggleFileTypeStats() );
+
+    _ui->actionFileTypeStats->setShortcutContext( Qt::ApplicationShortcut );
 
 
 
@@ -738,18 +740,23 @@ void MainWindow::openConfigDialog()
 }
 
 
-void MainWindow::openFileTypeStats()
+void MainWindow::toggleFileTypeStats()
 {
     if ( _fileTypeStatsWindow )
-        return;
+    {
+        _fileTypeStatsWindow->deleteLater();
+        // No need to set the variable to 0 - it is a guarded QPointer
+    }
+    else
+    {
+        // This deletes itself when the user closes it. The associated QPointer
+        // keeps track of that and sets the pointer to 0 when it happens.
 
-    // This deletes itself when the user closes it. The associated QPointer
-    // keeps track of that and sets the pointer to 0 when it happens.
-
-    _fileTypeStatsWindow = new QDirStat::FileTypeStatsWindow( _dirTreeModel->tree(),
-                                                              _selectionModel,
-                                                              this );
-    _fileTypeStatsWindow->show();
+        _fileTypeStatsWindow = new QDirStat::FileTypeStatsWindow( _dirTreeModel->tree(),
+                                                                  _selectionModel,
+                                                                  this );
+        _fileTypeStatsWindow->show();
+    }
 }
 
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -220,9 +220,9 @@ protected slots:
     void openConfigDialog();
 
     /**
-     * Open the file type statistics window.
+     * Open or close the file type statistics window.
      **/
-    void openFileTypeStats();
+    void toggleFileTypeStats();
 
     /**
      * Switch verbose logging for selection changes on or off.

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -202,6 +202,12 @@ protected slots:
     void showTreemapView();
 
     /**
+     * Switch between showing the treemap view beside the file directory
+     * or below it, depending on the corresponding action.
+     **/
+    void treemapAsSidePanel();
+
+    /**
      * Notification that a cleanup action was started.
      **/
     void startingCleanup( const QString & cleanupName );

--- a/src/main-window.ui
+++ b/src/main-window.ui
@@ -585,6 +585,7 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+   </property>
   </action>
   <action name="actionTreemapAsSidePanel">
    <property name="checkable">

--- a/src/main-window.ui
+++ b/src/main-window.ui
@@ -23,7 +23,7 @@
     <item>
      <widget class="QSplitter" name="mainWinSplitter">
       <property name="orientation">
-       <enum>Qt::Vertical</enum>
+       <enum>Qt::Horizontal</enum>
       </property>
       <widget class="QDirStat::DirTreeView" name="dirTreeView"/>
       <widget class="QDirStat::TreemapView" name="treemapView"/>
@@ -93,6 +93,7 @@
      <string>Tree&amp;map</string>
     </property>
     <addaction name="actionShowTreemap"/>
+    <addaction name="actionTreemapAsSidePanel"/>
     <addaction name="separator"/>
     <addaction name="actionTreemapZoomIn"/>
     <addaction name="actionTreemapZoomOut"/>
@@ -567,6 +568,7 @@
     <string>F7</string>
    </property>
   </action>
+<<<<<<< HEAD
   <action name="actionFileTypeStats">
    <property name="text">
     <string>File &amp;Type Statistics</string>
@@ -584,6 +586,19 @@
    </property>
    <property name="shortcut">
     <string>F1</string>
+  </action>
+  <action name="actionTreemapAsSidePanel">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Treeemap as side panel</string>
+   </property>
+   <property name="toolTip">
+    <string>Show the Treeemap beside the directory tree, otherwise it will be shown beneath.</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Hello,

It seems to me that on a widescreen monitor it makes sense to be able to put the treemap beside the directory tree.  As it wasnt a great deal of modification I thought I would give it a go (I havent used C++ since my university days but I have used a wide range of tech from Java, C# to php, js and a few obscure things inbetween).

Feel free to move around, edit or refuse my code but some feedback would be appreciated.

Cheers