### PR TITLE
fix UTF-8 in error messages

### DIFF
--- a/src/DirReadJob.cpp
+++ b/src/DirReadJob.cpp
@@ -278,7 +278,7 @@ void LocalDirReadJob::startReading()
 		}
 		else			// lstat() error
 		{
-		    logWarning() << "lstat(" << fullName << ") failed: " << strerror( errno ) << endl;
+		    logWarning() << "lstat(" << fullName << ") failed: " << QString::fromUtf8( strerror( errno ) ) << endl;
 
 		    /*
 		     * Not much we can do when lstat() didn't work; let's at

--- a/src/DirTreeCache.cpp
+++ b/src/DirTreeCache.cpp
@@ -53,7 +53,7 @@ bool CacheWriter::writeCache( const QString & fileName, DirTree *tree )
 
     if ( cache == 0 )
     {
-	logError() << "Can't open " << fileName << ": " << strerror( errno ) << endl;
+	logError() << "Can't open " << fileName << ": " << QString::fromUtf8( strerror( errno ) ) << endl;
 	return false;
     }
 
@@ -238,7 +238,7 @@ CacheReader::CacheReader( const QString & fileName,
 
     if ( _cache == 0 )
     {
-	logError() << "Can't open " << fileName << ": " << strerror( errno ) << endl;
+	logError() << "Can't open " << fileName << ": " << QString::fromUtf8( strerror( errno ) ) << endl;
 	_ok = false;
 	emit error();
 	return;

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -40,7 +40,7 @@ QString SysCallFailedException::errMsg( const QString & sysCall,
 	msg = QObject::tr( "%1( \"%2\" ) failed: %3" )
 	    .arg( sysCall )
 	    .arg( resourceName )
-	    .arg( strerror( errno ) );
+	    .arg( QString::fromUtf8( strerror( errno ) ) );
     }
     else
     {

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -401,7 +401,7 @@ QString Logger::createLogDir( const QString & rawLogDir )
 	else
 	{
 	    logError() << "Could not create log dir " << nameTemplate
-		       << ": " << strerror( errno ) << endl;
+		       << ": " << QString::fromUtf8( strerror( errno ) ) << endl;
 
 	    logDir = "/";
 	    // No permissions to write to /,

--- a/src/Trash.cpp
+++ b/src/Trash.cpp
@@ -68,7 +68,7 @@ dev_t Trash::device( const QString & path )
     if ( result < 0 )
     {
 	logError() << "stat( " << path << " ) failed: "
-		   << strerror( errno ) << endl;
+		   << QString::fromUtf8( strerror( errno ) ) << endl;
 
 	dev = static_cast<dev_t>( -1 );
     }
@@ -132,7 +132,7 @@ TrashDir * Trash::trashDir( const QString & path )
 	    // stat() failed for some other reason (not "no such file or directory")
 
 	    THROW( FileException( trashPath, "stat() failed for " + trashPath
-				  + ": " + strerror( errno ) ) );
+				  + ": " + QString::fromUtf8( strerror( errno ) ) ) );
 	}
 	else // stat() was successful
 	{
@@ -280,7 +280,7 @@ bool TrashDir::ensureDirExists( const QString & path,
     {
 	THROW( FileException( path,
 			      QString( "Could not create directory %1: %2" )
-			      .arg( path ).arg( strerror( errno ) ) ) );
+			      .arg( path ).arg( QString::fromUtf8( strerror( errno ) ) ) ) );
     }
 
     return result >= 0;


### PR DESCRIPTION
All strings read from glibc are in locale encoding, so fromUtf8() must be used before using them.

before:
`
2017-06-01 18:55:18.101 [4713] <WARNING> DirReadJob.cpp:281 startReading():  lstat(/tmp/aaa/krowa/dir2/sdsad) failed: Brak dostÄpu
`

after patch:
`
2017-06-01 19:05:18.558 [5768] <WARNING> DirReadJob.cpp:281 startReading():  lstat(/tmp/aaa/krowa/dir2/sdsad) failed: Brak dostępu
`