### PR TITLE
Fix qdirstat-cache-writer raw link in docs

### DIFF
--- a/doc/QDirStat-for-Servers.md
+++ b/doc/QDirStat-for-Servers.md
@@ -25,7 +25,7 @@ can fetch it directly from GitHub:
 
     ssh root@myserver
     cd /usr/local/bin
-    wget https://github.com/shundhammer/qdirstat/blob/master/scripts/qdirstat-cache-writer
+    wget https://github.com/shundhammer/qdirstat/raw/master/scripts/qdirstat-cache-writer
 
 By all means, have a look inside to convince yourself that there is no
 malicious code. It's a very simple script.


### PR DESCRIPTION
Previously it linked to the HTML page not the actual file.