### PR TITLE
Use errno.h for building on Haiku.

### DIFF
--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -6,8 +6,11 @@
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */
 
-
-#include <sys/errno.h>
+#if defined(__HAIKU__)
+    #include <errno.h>
+#else
+    #include <sys/errno.h>
+#endif
 
 #include "Exception.h"
 


### PR DESCRIPTION
This pull request fixes a build issue when including the errno.h on Haiku.