### PR TITLE
MacOS X: Disable doc dir, no icons in menus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 Makefile
 .qmake.stash
+
+# osx app bundle
+*.app

--- a/qdirstat.pro
+++ b/qdirstat.pro
@@ -18,4 +18,6 @@
 TEMPLATE = subdirs
 CONFIG  += ordered
 
-SUBDIRS  = src scripts doc doc/stats man
+SUBDIRS  = src scripts
+
+!macx:SUBDIRS += doc doc/stats man

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,11 @@ int main( int argc, char *argv[] )
     Logger logger( "/tmp/qdirstat-$USER", "qdirstat.log" );
     logVersion();
 
+    // Don't use icons on mac menus
+#ifdef Q_OS_MAC
+    QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+#endif
+
     // Set org/app name for QSettings
     QCoreApplication::setOrganizationName( "QDirStat" );
     QCoreApplication::setApplicationName ( "QDirStat" );


### PR DESCRIPTION
I downloaded and try to build QDirStat. Got a few errors builing doc & man. Since those features are not useful for the average macJoe user those subdirs are now build on non-mac OSes.

Also applications on mac don't display icons on menus, so I disabled that too.

Finally, add application bundle (*.app) to ignored files.


Changes tested against macOS High Sierra and Qt 5.10.1