### PR TITLE
[qt4] Adjustments for recent changes

### DIFF
--- a/src/PkgManager.cpp
+++ b/src/PkgManager.cpp
@@ -11,6 +11,7 @@
 #include <QProcess>
 
 #include "PkgManager.h"
+#include "Process.h"
 #include "Logger.h"
 #include "Exception.h"
 
@@ -188,7 +189,7 @@ QString PkgManager::runCommand( const QString &	    command,
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert( "LANG", "C" ); // Prevent output in translated languages
 
-    QProcess process;
+    Process process;
     process.setProgram( command );
     process.setArguments( args );
     process.setProcessEnvironment( env );

--- a/src/Qt4Compat.h
+++ b/src/Qt4Compat.h
@@ -13,6 +13,7 @@
 
 
 #if (QT_VERSION < QT_VERSION_CHECK( 5, 0, 0 ))
+#include <qtextdocument.h>
 #  define setSectionResizeMode setResizeMode
 #  define sectionResizeMode    resizeMode
 


### PR DESCRIPTION
use the QProcess compat wrapper in the new PkgManager.  Also
Qt::escape is only declared in <qtextdocument.h>, it's not
included with just <Qt> :-/

Signed-off-by: Michael Matz <matz@suse.de>