### PR TITLE
Exclude directories containing file.

### DIFF
--- a/src/DirTree.cpp
+++ b/src/DirTree.cpp
@@ -19,11 +19,12 @@
 using namespace QDirStat;
 
 
-DirTree::DirTree()
-    : QObject()
+DirTree::DirTree():
+    QObject(),
+    _crossFileSystems( false ),
+    _excludeDirWithFile( false ),
+    _isBusy( false )
 {
-    _isBusy	      = false;
-    _crossFileSystems = false;
     _root = new DirInfo( this );
     CHECK_NEW( _root );
 

--- a/src/DirTree.h
+++ b/src/DirTree.h
@@ -179,6 +179,31 @@ namespace QDirStat
 	    { _crossFileSystems = doCross; }
 
 	/**
+	 * Whether directory scans should avoid recursing into directories
+	 * containing excludeDirFilename.
+	 */
+	bool excludeDirWithFile() const { return _excludeDirWithFile; }
+
+	/**
+	 * Set or unset the "exclude dir with file" flag.
+	 */
+	void setExcludeDirWithFile( bool exclude )
+	    { _excludeDirWithFile = exclude; }
+
+	/**
+	 * Filename which, when encountered for a regular file in a directory,
+	 * indicates that the directory should not be scanned (when excludeDirWithFile
+	 * is set).
+	 */
+	QString excludeDirFilename() const { return _excludeDirFilename; }
+
+	/**
+	 * Set the filename that marks a directory for exclusion.
+	 */
+	void setExcludeDirFilename( const QString & name )
+	    { _excludeDirFilename = name; }
+
+	/**
 	 * Notification that a child has been added.
 	 *
 	 * Directory read jobs are required to call this for each child added
@@ -353,10 +378,12 @@ namespace QDirStat
     protected:
 
 	DirInfo *	_root;
-	DirReadJobQueue _jobQueue;
+	DirReadJobQueue	_jobQueue;
 	bool		_crossFileSystems;
+	bool		_excludeDirWithFile;
+	QString		_excludeDirFilename;
 	bool		_isBusy;
-        QString         _device;
+	QString		_device;
 
     };	// class DirTree
 
@@ -364,4 +391,3 @@ namespace QDirStat
 
 
 #endif // ifndef DirTree_h
-

--- a/src/DirTreeModel.cpp
+++ b/src/DirTreeModel.cpp
@@ -55,7 +55,9 @@ void DirTreeModel::readSettings()
     Settings settings;
     settings.beginGroup( "DirectoryTree" );
 
-    _tree->setCrossFileSystems( settings.value( "CrossFileSystems", false ).toBool() );
+    _tree->setCrossFileSystems  ( settings.value( "CrossFileSystems"   , false ).toBool() );
+    _tree->setExcludeDirWithFile( settings.value( "ExcludeDirWithFile" , false ).toBool() );
+    _tree->setExcludeDirFilename( settings.value( "ExcludeDirFilename" , ""    ).toString() );
     _treeIconDir	 = settings.value( "TreeIconDir" , ":/icons/tree-medium/" ).toString();
     _updateTimerMillisec = settings.value( "UpdateTimerMillisec", 333 ).toInt();
     _slowUpdateMillisec	 = settings.value( "SlowUpdateMillisec", 3000 ).toInt();
@@ -69,11 +71,13 @@ void DirTreeModel::writeSettings()
     Settings settings;
     settings.beginGroup( "DirectoryTree" );
 
-    settings.setValue( "SlowUpdateMillisec", _slowUpdateMillisec  );
+    settings.setValue( "SlowUpdateMillisec", _slowUpdateMillisec );
 
-    settings.setDefaultValue( "CrossFileSystems",    _tree ? _tree->crossFileSystems() : false );
-    settings.setDefaultValue( "TreeIconDir" ,	     _treeIconDir	  );
-    settings.setDefaultValue( "UpdateTimerMillisec", _updateTimerMillisec );
+    settings.setDefaultValue( "CrossFileSystems"    , _tree ? _tree->crossFileSystems()   : false );
+    settings.setDefaultValue( "ExcludeDirWithFile"  , _tree ? _tree->excludeDirWithFile() : false );
+    settings.setDefaultValue( "ExcludeDirFilename"  , _tree ? _tree->excludeDirFilename() : ""    );
+    settings.setDefaultValue( "TreeIconDir"         , _treeIconDir         );
+    settings.setDefaultValue( "UpdateTimerMillisec" , _updateTimerMillisec );
 
     settings.endGroup();
 }
@@ -1056,4 +1060,3 @@ void DirTreeModel::refreshSelected()
 	logWarning() << "NOT refreshing " << sel << endl;
     }
 }
-

--- a/src/FileSizeStatsWindow.cpp
+++ b/src/FileSizeStatsWindow.cpp
@@ -72,19 +72,7 @@ FileSizeStatsWindow * FileSizeStatsWindow::sharedInstance()
 {
     if ( ! _sharedInstance )
     {
-	QWidget * parent = 0;
-
-	QWidgetList toplevel = QApplication::topLevelWidgets();
-
-	for ( QWidgetList::const_iterator it = toplevel.constBegin();
-	      it != toplevel.constEnd() && ! parent;
-	      ++it )
-	{
-	    parent = qobject_cast<MainWindow *>( *it );
-	}
-
-	if ( ! parent )
-	    logWarning() << "NULL parent for shared instance" << endl;
+	QWidget * parent = MainWindow::activeWindow();
 
 	_sharedInstance = new FileSizeStatsWindow( parent );
 	CHECK_NEW( _sharedInstance );

--- a/src/GeneralConfigPage.cpp
+++ b/src/GeneralConfigPage.cpp
@@ -73,8 +73,10 @@ void GeneralConfigPage::readSettings()
 
     settings.beginGroup( "DirectoryTree" );
 
-    _ui->crossFileSystemsCheckBox->setChecked( settings.value( "CrossFileSystems"    , false ).toBool() );
-    _ui->treeUpdateIntervalSpinBox->setValue ( settings.value( "UpdateTimerMillisec" ,   333 ).toInt()  );
+    _ui->crossFileSystemsCheckBox->setChecked  ( settings.value( "CrossFileSystems"    , false       ).toBool() );
+    _ui->excludeDirWithFileCheckBox->setChecked( settings.value( "ExcludeDirWithFile"  , false       ).toBool() );
+    _ui->excludeDirFilenameLineEdit->setText   ( settings.value( "ExcludeDirFilename"  , ".nobackup" ).toString() );
+    _ui->treeUpdateIntervalSpinBox->setValue   ( settings.value( "UpdateTimerMillisec" , 333         ).toInt() );
     QString treeIconDir = settings.value( "TreeIconDir", ":/icons/tree-medium" ).toString();
 
     int index = treeIconDir.endsWith( "medium" ) ? 0 : 1;
@@ -100,8 +102,10 @@ void GeneralConfigPage::writeSettings()
 
     settings.beginGroup( "DirectoryTree" );
 
-    settings.setValue( "CrossFileSystems"    , _ui->crossFileSystemsCheckBox->isChecked() );
-    settings.setValue( "UpdateTimerMillisec" , _ui->treeUpdateIntervalSpinBox->value()    );
+    settings.setValue( "CrossFileSystems"    , _ui->crossFileSystemsCheckBox->isChecked()   );
+    settings.setValue( "ExcludeDirWithFile"  , _ui->excludeDirWithFileCheckBox->isChecked() );
+    settings.setValue( "ExcludeDirFilename"  , _ui->excludeDirFilenameLineEdit->text()      );
+    settings.setValue( "UpdateTimerMillisec" , _ui->treeUpdateIntervalSpinBox->value()      );
 
     switch ( _ui->treeIconThemeComboBox->currentIndex() )
     {

--- a/src/GeneralConfigPage.cpp
+++ b/src/GeneralConfigPage.cpp
@@ -8,6 +8,8 @@
 
 
 #include "GeneralConfigPage.h"
+#include "DirTreeModel.h"
+#include "MainWindow.h"
 #include "Settings.h"
 #include "Logger.h"
 #include "Exception.h"
@@ -39,11 +41,25 @@ void GeneralConfigPage::setup()
 }
 
 
+static DirTreeModel * dirTreeModel()
+{
+    DirTreeModel * result = 0;
+    const MainWindow * window = MainWindow::activeWindow();
+    if ( ! window )
+        return result;
+    return window->dirTreeModel();
+}
+
+
 void GeneralConfigPage::applyChanges()
 {
     // logDebug() << endl;
 
     writeSettings();
+
+    DirTreeModel * model = dirTreeModel();
+    if ( model )
+        model->readSettings();
 }
 
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -599,6 +599,23 @@ void MainWindow::readingAborted()
 }
 
 
+MainWindow * MainWindow::activeWindow()
+{
+    MainWindow * result = 0;
+
+    QWidgetList toplevel = QApplication::topLevelWidgets();
+
+    for ( QWidgetList::const_iterator it = toplevel.constBegin();
+          it != toplevel.constEnd() && ! result;
+          ++it )
+    {
+        result = qobject_cast<MainWindow *>( *it );
+    }
+
+    return result;
+}
+
+
 void MainWindow::openUrl( const QString & url )
 {
     QString windowTitle = "QDirStat";

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -53,6 +53,11 @@ public:
      **/
     QDirStat::DirTreeModel * dirTreeModel() const { return _dirTreeModel; }
 
+    /**
+     * Return the active main window, if any.
+     */
+    static MainWindow * activeWindow();
+
 public slots:
 
     /**

--- a/src/general-config-page.ui
+++ b/src/general-config-page.ui
@@ -65,6 +65,35 @@
          </property>
         </widget>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QCheckBox" name="excludeDirWithFileCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QLabel" name="excludDirWithFileCaption">
+             <property name="text">
+              <string>Exclude Directories With File</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="excludeDirFilenameLineEdit">
+             <property name="text">
+              <string>.nobackup</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
This is not ready, but I wanted to check that this is an OK approach.

The use case mentioned in #90 requires only that a single static filename be configurable for excluding directories. Giving users the ability to set this single filename should be sufficient to provide the most benefit for the least increase in complexity. Users that want to check for multiple files can use a tool like `find` to locate files by pattern or using multiple filenames and create the necessary file checked by QDirStat. Further, we do not handle edge cases or try to emulate a particular backup program with respect to validating the file has any particular attributes or contents. A user may already check for edge cases like that using `find`/`grep`/`diff`.

Missing from this PR is the changed filename taking effect immediately when the settings are saved.