### PR TITLE
Added missing headers for Qt4 support

### DIFF
--- a/src/DataColumns.h
+++ b/src/DataColumns.h
@@ -12,6 +12,7 @@
 
 #include <QList>
 #include <QString>
+#include <QStringList>
 #include <QObject>
 #include <QTextStream>
 


### PR DESCRIPTION
Minor fix: include directive for <QStringList> added to DataColumns.h. Some combination of Qt and gcc versions don't build QDirStat without it.