### PR TITLE
When compression is requested, do it in one pass

### DIFF
--- a/scripts/qdirstat-cache-writer
+++ b/scripts/qdirstat-cache-writer
@@ -118,7 +118,6 @@ sub main()
     }
 
     write_cache_file( $toplevel_dir, $cache_file_name );
-    compress_file( $cache_file_name );
 }
 
 
@@ -136,7 +135,16 @@ sub write_cache_file()
     my ( $toplevel_dir, $cache_file_name ) = @_;
     my $start_time = time();
 
-    open( CACHE,  ">" . $cache_file_name ) or die "Can't open $cache_file_name";
+    my $open_type = ">";
+    my $open_name = $cache_file_name;
+
+    if ( $cache_file_name =~ /.*\.gz$/ )
+    {
+	$open_type = "|-";
+	$open_name = "gzip > '$cache_file_name'";
+    }
+
+    open( CACHE,  $open_type , $open_name ) or die "Can't open $cache_file_name";
     binmode( CACHE, ":bytes" );
     write_cache_header();
     write_cache_tree( $toplevel_dir );
@@ -146,30 +154,6 @@ sub write_cache_file()
     printf CACHE "# Elapsed time: %d:%02d:%02d\n", $hours, $min, $sec;
 
     close( CACHE );
-}
-
-
-#-----------------------------------------------------------------------------
-
-
-# Compress a file if its extension is ".gz".
-#
-# Parameters:
-#	$file_name
-
-sub compress_file()
-{
-    my ( $file_name ) = @_;
-
-    if ( $file_name =~ /.*\.gz$/ )
-    {
-	my $uncompressed_name = $file_name;
-	$uncompressed_name =~ s/\.gz$//;	# Cut off ".gz" extension
-	rename( $file_name, $uncompressed_name );
-	logf( "Compressing $file_name" );
-	system( "gzip $uncompressed_name" );
-    }
-
 }
 
 

--- a/scripts/qdirstat-cache-writer
+++ b/scripts/qdirstat-cache-writer
@@ -135,13 +135,15 @@ sub write_cache_file()
     my ( $toplevel_dir, $cache_file_name ) = @_;
     my $start_time = time();
 
+    my $cache_file_name_part = $cache_file_name . ".part";
+
     my $open_type = ">";
-    my $open_name = $cache_file_name;
+    my $open_name = $cache_file_name_part;
 
     if ( $cache_file_name =~ /.*\.gz$/ )
     {
 	$open_type = "|-";
-	$open_name = "gzip > '$cache_file_name'";
+	$open_name = "gzip > '$open_name'";
     }
 
     open( CACHE,  $open_type , $open_name ) or die "Can't open $cache_file_name";
@@ -154,6 +156,7 @@ sub write_cache_file()
     printf CACHE "# Elapsed time: %d:%02d:%02d\n", $hours, $min, $sec;
 
     close( CACHE );
+    rename($cache_file_name_part, $cache_file_name);
 }
 
 


### PR DESCRIPTION
Rather than writing the entire uncompressed cache file,
then compressing in a 2nd pass (which consumes *much* more
space, and is slower due to all the I/O)...

Instead write the output to a pipeline that compresses via external
gzip during the first (and only) pass.

This preserves the "no addititional dependencies" theme in the current
perl script, doing this via the same external gzip program used by
the former 2-pass approach.  Presumably because the headless server
running this script may be a very minimal embedded linux, *BSD, etc.

Single process sol'n can use ">:gzip" from the perl IO gzip layer
(packaged as libperlio-gzip-perl in debian/ubuntu), but not sure
if this is available on all servers you want to support.

2nd bundled commit ensures that (whether doing compression or not), complete results are dropped into place atomically via a rename().