### PR TITLE
Compiles under macos

### DIFF
--- a/qdirstat.pro
+++ b/qdirstat.pro
@@ -19,3 +19,7 @@ TEMPLATE = subdirs
 CONFIG  += ordered
 
 SUBDIRS  = src scripts doc doc/stats man
+
+macx {
+    SUBDIRS  -= scripts doc doc/stats man
+}


### PR DESCRIPTION
According to bug https://github.com/shundhammer/qdirstat/issues/65 by removing all folders except src, the application is able to compile and run.