### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Download installable binary packages for various Linux distributions here:
 
     If you started QDirStat with a path on the command line, it collected the
     information about used / free / reserved disk space for all mounted
-    filesytems already. If you had a network mount that didn't respond, you
+    filesystems already. If you had a network mount that didn't respond, you
     still had to wait for a timeout before the program could continue.
 
     Now it collects that information only when it's really needed:
@@ -877,7 +877,7 @@ Features ported from the old KDirStat:
 
 <details>
 
-- KPacman: That was that PacMan animation wile reading directory reading. This
+- KPacman: That was that PacMan animation while reading directory reading. This
   is gone now. KPacMan looked out of place pretty soon after it got to KDirStat
   due to Qt styles doing fancy rendering of widget backgrounds with gradients
   etc.  I know that it does have its fans, but it's unrealistic to get this

--- a/doc/Debugging-Tips.md
+++ b/doc/Debugging-Tips.md
@@ -40,7 +40,7 @@ https://unix.stackexchange.com/questions/87908/how-do-you-empty-the-buffers-and-
 
 ### Prerequisites
 
-Install vallgrind and kcachgrind:
+Install valgrind and kcachgrind:
 
     sudo apt install valgrind kcachegrind
 

--- a/doc/DevHistory.md
+++ b/doc/DevHistory.md
@@ -72,7 +72,7 @@ https://github.com/shundhammer/qdirstat/blob/master/README.md
 
     If you started QDirStat with a path on the command line, it collected the
     information about used / free / reserved disk space for all mounted
-    filesytems already. If you had a network mount that didn't respond, you
+    filesystems already. If you had a network mount that didn't respond, you
     still had to wait for a timeout before the program could continue.
 
     Now it collects that information only when it's really needed:
@@ -2726,7 +2726,7 @@ correctly when built with Qt 4.x
 
     As for migration from previous single-file configurations, QDirStat does
     that automatically: It reads the single file and moves the respective parts
-    where they belong. No need to bother with any migration scrips or anything
+    where they belong. No need to bother with any migration scripts or anything
     like that.
 
 
@@ -3104,7 +3104,7 @@ correctly when built with Qt 4.x
     give me problems for that "remove junk files" cleanup: "rm -f *.o *.bak *~"
     -- when any of the wildcards cannot be expanded because there is no such
     file, it complains. Okay, you can wrap the whole command in "/bin/bash -c",
-    but that's yet another indirection, so now you can configuare /bin/bash for
+    but that's yet another indirection, so now you can configure /bin/bash for
     that particular cleanup action. On the other hand, for some things I might
     want my original shell environment, so I do want my login shell by default.
     This is now the default behaviour: Try $SHELL (the user's login shell), and

--- a/src/DirTreeModel.cpp
+++ b/src/DirTreeModel.cpp
@@ -317,7 +317,7 @@ FileInfo * DirTreeModel::itemFromIndex( const QModelIndex & index )
 
 
 //
-// Reimplented from QAbstractItemModel
+// Reimplemented from QAbstractItemModel
 //
 
 int DirTreeModel::rowCount( const QModelIndex & parentIndex ) const

--- a/src/DirTreeModel.h
+++ b/src/DirTreeModel.h
@@ -251,7 +251,7 @@ namespace QDirStat
 	Qt::SortOrder sortOrder() const { return _sortOrder; }
 
 	//
-	// Reimplented from QAbstractItemModel:
+	// Reimplemented from QAbstractItemModel:
 	//
 
 	/**

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -471,7 +471,7 @@ FileInfo * FileInfo::locate( QString url, bool findPseudoDirs )
                 child = child->next();
             }
 
-            // logDebug() << "Cant find " << url << " in DotEntry" << endl;
+            // logDebug() << "Cannot find " << url << " in DotEntry" << endl;
 	}
 
 	if ( ! result && attic() )

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -471,7 +471,7 @@ protected:
      * Show an error popup that a directory could not be opened and wait until
      * the user confirmed it.
      *
-     * The relevant informatoin is all in the exception.
+     * The relevant information is all in the exception.
      **/
     void showOpenDirErrorPopup( const SysCallFailedException & ex );
 

--- a/src/SysUtil.h
+++ b/src/SysUtil.h
@@ -169,7 +169,7 @@ namespace QDirStat
         /**
          * Read the (first level) target of a symbolic link.
          * Unlike readLink( const QString & ) above, this does not make any
-         * assumptions of name encoding in the filessytem; it just uses bytes.
+         * assumptions of name encoding in the filesystem; it just uses bytes.
          *
          * This is a more user-friendly version of readlink(2).
          *


### PR DESCRIPTION
Found via `codespell -q 3 -L ro,te`