### PR TITLE
Add note for installing make to install URI::Escape to use qdirstat-cache-writer

### DIFF
--- a/doc/QDirStat-for-Servers.md
+++ b/doc/QDirStat-for-Servers.md
@@ -12,6 +12,7 @@ machine where you can view the data with the normal QDirStat application.
 
 - Perl
   - URI::Escape, install via `cpan URI::Escape`
+  - If installing URI::Escape fails, make sure `make` is installed (`apt install build-essential` or equivalent for your platform)
 - Some command to copy files to your desktop machine:
   scp, ftp or whatever
 


### PR DESCRIPTION
Tried installing URI::Escape on a new GCP VM, got a bunch of errors that I managed to track down to make not being installed for whatever reason. Fixed by installing `build-essential` and re-running `cpan URI::Escape`.

EDIT: I'm not sure about the language used for the note, feel free to make it better.