### PR TITLE
Update link to Fedora package page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ https://packages.debian.org/search?keywords=qdirstat
 
 ### Fedora
 
-https://apps.fedoraproject.org/packages/qdirstat/builds/
+https://packages.fedoraproject.org/pkgs/qdirstat/qdirstat/
 
 
 ## QDirStat Docker Containers


### PR DESCRIPTION
Update link to the page of the Fedora pre-built QDirStat package (old link was a 404)