### PR TITLE
Treemap Improvements

### DIFF
--- a/src/TreemapTile.cpp
+++ b/src/TreemapTile.cpp
@@ -198,6 +198,8 @@ void TreemapTile::createSquarifiedChildren( const QRectF & rect )
     FileSize remainingTotal = 0;
     for (FileInfoSortedBySizeIterator item=it; *item; ++item)
 	remainingTotal += (*item)->totalAllocatedSize();
+    if (minSize > 0)
+	remainingTotal = _orig->totalAllocatedSize();
 
     while ( *it )
     {

--- a/src/TreemapTile.h
+++ b/src/TreemapTile.h
@@ -247,7 +247,7 @@ namespace QDirStat
 	 * 'scale' is the scaling factor between file sizes and pixels.
 	 **/
 	FileInfoList squarify( const QRectF & rect,
-			       double	     scale,
+			       FileSize remainingTotal,
 			       FileInfoSortedBySizeIterator & it   );
 
 	/**
@@ -255,7 +255,9 @@ namespace QDirStat
 	 * Returns the new rectangle with the layouted area subtracted.
 	 **/
 	QRectF layoutRow( const QRectF	& rect,
-			  double	  scale,
+//			  double		scale,
+//			  FileSize	  rowTotal,
+			  FileSize	  remainingTotal,
 			  FileInfoList	& row );
 
 	/**


### PR DESCRIPTION
Changes for issues #223 and #224.

createSquarifiedChildren() is modified to support full squarification, laying out each row along the shorter dimension of the remaining rectangle instead of the longer one.  squarify() is largely rewritten to compile a row of tiles in the appropriate direction, choosing the row that makes the first and last tiles as close as possible to square.  layoutRow() is modified to lay out and scale along the shorter side of the remaining rectangle.  Rounding is controlled better to reduce tearing between tiles and ensure filling of each row.  With minTileSize=0, children are scaled to exactly fit the parent tile, ignoring the allocated size of the parent, just for neatness (symlinks are still shown, or not, with zero size).

The first call to addRidge() in layoutRow() is changed to be made against a new rectangle encompassing just that row instead of the whole remaining space.  This avoids the highlights being excessively pulled towards the bottom or right of the parent; they are now pulled modestly towards the centre of each row and somewhat towards the centre of their parents.

renderCushion() is modified to more closely match the algorithm in the published paper.  The initial color values are scaled to avoid ambient light overflow instead of being reduced by an absolute value (ie. dark colours are darkened less).  The signs of the X and Y coefficients are changed (I'm fairly sure this is how they are in the paper, but struggle to see much difference in the final cushions).  Some values are pre-calculated for speed (Ia, Is, and the adjusted lightX, lightY, and lightZ could all be calculated once and stored on the parent view, but that's for another day).