### PR TITLE
Make the executable and symlink mime type colours configurable

### DIFF
--- a/src/MimeCategorizer.cpp
+++ b/src/MimeCategorizer.cpp
@@ -297,20 +297,24 @@ void MimeCategorizer::writeSettings()
 
 void MimeCategorizer::ensureMandatoryCategories()
 {
-    if ( !matchCategoryName( CATEGORY_EXECUTABLE ) )
+    // Remember this category so we don't have to search for it every time
+    _executableCategory = matchCategoryName( CATEGORY_EXECUTABLE );
+    if ( !_executableCategory )
     {
 	// Special catchall category for files that don't match anything else, cannot be deleted
-	MimeCategory * executable = new MimeCategory( tr( CATEGORY_EXECUTABLE ), Qt::magenta );
-	CHECK_NEW( executable );
-	add( executable );
+	_executableCategory = new MimeCategory( tr( CATEGORY_EXECUTABLE ), Qt::magenta );
+	CHECK_NEW( _executableCategory );
+	add( _executableCategory );
     }
 
-    // Special category for symlinks regardless of the filename, cannot be deleted
-    if ( !matchCategoryName( CATEGORY_SYMLINK ) )
+    // Remember this category so we don't have to search for it every time
+    _symlinkCategory = matchCategoryName( CATEGORY_SYMLINK );
+    if ( !_symlinkCategory )
     {
-	MimeCategory * symlink = new MimeCategory( tr( CATEGORY_SYMLINK ), Qt::blue );
-	CHECK_NEW( symlink );
-	add( symlink );
+	// Special category for symlinks regardless of the filename, cannot be deleted
+	_symlinkCategory = new MimeCategory( tr( CATEGORY_SYMLINK ), Qt::blue );
+	CHECK_NEW( _symlinkCategory );
+	add( _symlinkCategory );
     }
 }
 

--- a/src/MimeCategorizer.cpp
+++ b/src/MimeCategorizer.cpp
@@ -55,6 +55,14 @@ void MimeCategorizer::clear()
 }
 
 
+QColor MimeCategorizer::color( FileInfo * item )
+{
+    MimeCategory *mimeCategory = category( item );
+
+    return mimeCategory ? mimeCategory->color() : Qt::white;
+}
+
+
 MimeCategory * MimeCategorizer::category( FileInfo * item )
 {
     CHECK_PTR  ( item );

--- a/src/MimeCategorizer.cpp
+++ b/src/MimeCategorizer.cpp
@@ -251,10 +251,10 @@ void MimeCategorizer::readSettings()
 	settings.endGroup(); // [MimeCategory_01], [MimeCategory_02], ...
     }
 
-    ensureMandatoryCategories();
-
     if ( _categories.isEmpty() )
 	addDefaultCategories();
+
+    ensureMandatoryCategories();
 }
 
 

--- a/src/MimeCategorizer.h
+++ b/src/MimeCategorizer.h
@@ -14,6 +14,9 @@
 
 #include "MimeCategory.h"
 
+#define CATEGORY_EXECUTABLE "Executable"
+#define CATEGORY_SYMLINK "Symlink"
+
 
 namespace QDirStat
 {
@@ -130,10 +133,21 @@ namespace QDirStat
 			  const QStringList		& suffixList  );
 
 	/**
+	 * Iterate over all categories to find categories by name.
+	 **/
+	MimeCategory * matchCategoryName( const QString & categoryName ) const;
+
+	/**
 	 * Iterate over all categories and try all patterns until the first
 	 * match. Return the matched category or 0 if none matched.
 	 **/
 	MimeCategory * matchPatterns( const QString & filename ) const;
+
+	/**
+	 * Make sure that the Executable and Symlink categories exist, in case
+	 * they have been manually removed from the configuration file.
+	 **/
+	void ensureMandatoryCategories();
 
 	/**
 	 * Add default categories in case none were read from the settings.

--- a/src/MimeCategorizer.h
+++ b/src/MimeCategorizer.h
@@ -166,6 +166,9 @@ namespace QDirStat
 	QMap<QString, MimeCategory *>	_caseInsensitiveSuffixMap;
 	QMap<QString, MimeCategory *>	_caseSensitiveSuffixMap;
 
+	MimeCategory *_executableCategory;
+	MimeCategory *_symlinkCategory;
+
     };	// class MimeCategorizer
 
 }	// namespace QDirStat

--- a/src/MimeCategorizer.h
+++ b/src/MimeCategorizer.h
@@ -60,6 +60,12 @@ namespace QDirStat
 	static MimeCategorizer * instance();
 
 	/**
+	 * Return the color for a FileInfo item or white if it doesn't fit
+	 * into any of the available categories.
+	 **/
+	QColor color( FileInfo * item );
+
+	/**
 	 * Return the MimeCategory for a FileInfo item or 0 if it doesn't fit
 	 * into any of the available categories.
 	 **/

--- a/src/MimeCategoryConfigPage.cpp
+++ b/src/MimeCategoryConfigPage.cpp
@@ -326,3 +326,19 @@ void MimeCategoryConfigPage::populateTreemapView()
     _ui->treemapView->setDirTree( _dirTree );
 }
 
+
+void MimeCategoryConfigPage::currentItemChanged( QListWidgetItem * current,
+                                                 QListWidgetItem * previous)
+{
+    ListEditor::currentItemChanged( current, previous );
+
+    const QString name = _ui->nameLineEdit->text();
+
+    const bool isSymlink = name == CATEGORY_SYMLINK;
+    _ui->patternsTopWidget->setEnabled( !isSymlink );
+    _ui->patternsBottomWidget->setEnabled( !isSymlink );
+
+    const bool editable = !( isSymlink || name == CATEGORY_EXECUTABLE );
+    enableButton( _ui->removeButton, editable );
+    _ui->nameLineEdit->setEnabled( editable );
+}

--- a/src/MimeCategoryConfigPage.h
+++ b/src/MimeCategoryConfigPage.h
@@ -125,6 +125,13 @@ namespace QDirStat
 	virtual QString deleteConfirmationMessage( void * value ) Q_DECL_OVERRIDE;
 
 	/**
+	 * Signal handler for a change in the list widget current item.
+	 *
+	 * Implemented from ListEditor.
+	 **/
+	virtual void currentItemChanged( QListWidgetItem * current, QListWidgetItem * previous) Q_DECL_OVERRIDE;
+
+	/**
 	 * Convert 'patternList' into a newline-separated string and set it as
 	 * text of 'textEdit'.
 	 **/

--- a/src/TreemapView.cpp
+++ b/src/TreemapView.cpp
@@ -19,7 +19,6 @@
 #include "SettingsHelpers.h"
 #include "SignalBlocker.h"
 #include "TreemapTile.h"
-#include "MimeCategorizer.h"
 #include "DelayedRebuilder.h"
 #include "Exception.h"
 #include "Logger.h"
@@ -626,7 +625,7 @@ TreemapTile * TreemapView::findTile( const FileInfo * fileInfo )
     if ( ! fileInfo || ! scene() )
 	return 0;
 
-    foreach ( QGraphicsItem * graphicsItem, scene()->items() )
+    foreach ( QGraphicsItem *graphicsItem, scene()->items() )
     {
 	TreemapTile * tile = dynamic_cast<TreemapTile *>(graphicsItem);
 
@@ -651,16 +650,6 @@ void TreemapView::setFixedColor( const QColor & color )
 {
     _fixedColor	   = color;
     _useFixedColor = _fixedColor.isValid();
-}
-
-
-QColor TreemapView::tileColor( FileInfo * file )
-{
-    if ( _useFixedColor )
-        return _fixedColor;
-
-    MimeCategory * category = MimeCategorizer::instance()->category( file );
-    return category ? category->color() : Qt::white;
 }
 
 

--- a/src/TreemapView.cpp
+++ b/src/TreemapView.cpp
@@ -354,11 +354,13 @@ void TreemapView::rebuildTreemap( FileInfo *	 newRoot,
 
 	if ( newRoot )
 	{
+	    _stopwatch.start();
 	    _rootTile = new TreemapTile( this,		// parentView
 					 0,		// parentTile
 					 newRoot,	// orig
 					 rect,
 					 TreemapAuto );
+		logDebug() << _stopwatch.restart() << endl;
 	}
 
 
@@ -655,31 +657,10 @@ void TreemapView::setFixedColor( const QColor & color )
 QColor TreemapView::tileColor( FileInfo * file )
 {
     if ( _useFixedColor )
-	return _fixedColor;
+        return _fixedColor;
 
-    if ( file )
-    {
-	if ( file->isFile() )
-	{
-	    MimeCategory * category = MimeCategorizer::instance()->category( file );
-
-	    if ( category )
-		return category->color();
-	    else
-	    {
-		// Special case: Executables
-		if ( ( file->mode() & S_IXUSR  ) == S_IXUSR )
-		    return Qt::magenta;		// TO DO: Configurable
-	    }
-	}
-	else // Directories
-	{
-	    // TO DO
-	    return Qt::blue;
-	}
-    }
-
-    return Qt::white;
+    MimeCategory * category = MimeCategorizer::instance()->category( file );
+    return category ? category->color() : Qt::white;
 }
 
 

--- a/src/TreemapView.h
+++ b/src/TreemapView.h
@@ -15,7 +15,9 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsPathItem>
 #include <QList>
+#include <QElapsedTimer>
 
+#include "MimeCategorizer.h"
 #include "FileInfo.h"
 
 
@@ -59,6 +61,8 @@ namespace QDirStat
 	Q_OBJECT
 
     public:
+	QElapsedTimer _stopwatch;
+
 	/**
 	 * Constructor. Remember to set the directory tree with setDirTree()
 	 * and the selection model with setSelectionModel() after creating this
@@ -140,7 +144,8 @@ namespace QDirStat
 	 * Returns a suitable color for 'file' based on a set of internal rules
 	 * (according to filename extension, MIME type or permissions).
 	 **/
-	QColor tileColor( FileInfo * file );
+	QColor tileColor( FileInfo * file ) const
+		{ return _useFixedColor ? _fixedColor : MimeCategorizer::instance()->color( file ); }
 
 	/**
 	 * Use a fixed color for all tiles. To undo this, set an invalid QColor


### PR DESCRIPTION
This code in treemapView was marked TO DO, so I did.  There are now two extra categories:
- one for executable files that don't match anything else;
-  one for all symlinks regardless of the name
The two categories cannot be deleted from the config dialog and will be recreated if they are lost from the config file.  The colours can be configured.  Patterns can be added for the executable category, but not for the symlink one.