### PR TITLE
Mime categorizer config fixes

### DIFF
--- a/src/MimeCategoryConfigPage.cpp
+++ b/src/MimeCategoryConfigPage.cpp
@@ -346,8 +346,8 @@ void MimeCategoryConfigPage::currentItemChanged( QListWidgetItem * current,
 
 void MimeCategoryConfigPage::setActions( const QListWidgetItem * currentItem )
 {
-    const bool isSymlink = currentItem && currentItem->text() == CATEGORY_SYMLINK;
-    const bool isExecutable = currentItem && currentItem->text() == CATEGORY_EXECUTABLE;
+    const bool isSymlink = currentItem && currentItem->text() == CATEGORY_SYMLINKS;
+    const bool isExecutable = currentItem && currentItem->text() == CATEGORY_EXECUTABLES;
 
     // Name can't be changed for symlinks and executables
     _ui->nameLineEdit->setEnabled( currentItem && !isSymlink && !isExecutable );

--- a/src/MimeCategoryConfigPage.h
+++ b/src/MimeCategoryConfigPage.h
@@ -132,6 +132,21 @@ namespace QDirStat
 	virtual void currentItemChanged( QListWidgetItem * current, QListWidgetItem * previous) Q_DECL_OVERRIDE;
 
 	/**
+	 * Update actions to match the current item properties.
+	 *
+	 * Implemented from ListEditor.
+	 **/
+	virtual void updateActions() Q_DECL_OVERRIDE;
+
+	/**
+	 * Set the remove button, name, and patterns enabled or disabled,
+	 * based on the name of the current category item.
+	 *
+	 * Called by currentItemChanged() and updateActions().
+	 **/
+	void setActions( const QListWidgetItem * currentItem );
+
+	/**
 	 * Convert 'patternList' into a newline-separated string and set it as
 	 * text of 'textEdit'.
 	 **/


### PR DESCRIPTION
Override the ListEditor updateActions() so that the remove button remains disabled for the symlink and executable categories when they become the current item after a category has been deleted.

Disable everything except the add button when there are no categories (shouldn't happen but was happening in some cases before this fix).  Also set the mini-treemap to the default fixed colour when the last category is removed, and reset the name, colour and patterns in the dialog.

See issue #238.