### PR TITLE
Added missing include for `uid_t` type.

### DIFF
--- a/src/SystemFileChecker.h
+++ b/src/SystemFileChecker.h
@@ -10,6 +10,7 @@
 #ifndef SystemFileChecker_h
 #define SystemFileChecker_h
 
+#include <sys/types.h> // uid_t
 
 #include <QString>
 


### PR DESCRIPTION
Found while compiling version 1.9.  This fixes the following compilation error (at least under clang), caused by missing include for `uid_t`.
```
SystemFileChecker.cpp:43:25: error: out-of-line definition of 'isSystemUid' does not match any declaration in 'QDirStat::SystemFileChecker'
bool SystemFileChecker::isSystemUid( uid_t uid )