### PR TITLE
Fix use of null pointer during AssumeDeleted cleanup

### DIFF
--- a/src/SelectionModel.cpp
+++ b/src/SelectionModel.cpp
@@ -264,7 +264,7 @@ void SelectionModel::deletingChildNotify( FileInfo * deletedChild )
     _selectedItemsDirty = true;
     _selectedItems.clear();
 
-    if ( _currentItem->isInSubtree( deletedChild ) )
+    if ( _currentItem && _currentItem->isInSubtree( deletedChild ) )
 	setCurrentItem( 0 );
 }
 


### PR DESCRIPTION
During an AssumeDeleted cleanup, SelectionModel checks to see if the current item has been deleted.  Unfortunately, if the current item has been deleted, then the pointer to it is already invalid.  Check the pointer first; if it is already null then we don't need to set it to null.  Is the check ever meaningful?  Can the current item ever not be in the subtree that is being cleaned up?