### PR TITLE
fixes for musl libc

### DIFF
--- a/src/FormatUtil.h
+++ b/src/FormatUtil.h
@@ -18,6 +18,9 @@
 
 #include "FileSize.h"
 
+#ifndef ALLPERMS
+#define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
 
 namespace QDirStat
 {

--- a/src/SystemFileChecker.cpp
+++ b/src/SystemFileChecker.cpp
@@ -7,6 +7,8 @@
  */
 
 
+#include <sys/types.h>
+
 #include "SystemFileChecker.h"
 #include "DirInfo.h"
 


### PR DESCRIPTION
Two small changes are necessary to successfully build on musl libc.
I have been adding the `ALLPERMS` patch downstream for a couple of years now and forgot to post it here.
The `uid_t` is new and is needed to fix https://github.com/void-linux/void-packages/actions/runs/8342934314/job/22832155263?pr=49372#step:7:172