### PR TITLE
README.md: fix Treemap link in the New Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ old code base that had been long overdue.
     - Shift-click: Select a range of items.
     - Ctrl-Click:  Select an additional item or deselect a selected one.
 
-  - {Treemap](doc/Treemap.md):
+  - [Treemap](doc/Treemap.md):
     - Ctrl-Click:  Select an additional item or deselect a selected one.
 
     - The current item is highlighted with a red rectangle, all other selected


### PR DESCRIPTION
The markdown for the link to the _Treemap_ docs in the _New Features_ section was bork by a single opening brace character.