### PR TITLE
Skip /System/Volumes/Data on macOS to avoid double-counting

### DIFF
--- a/src/DirReadJob.cpp
+++ b/src/DirReadJob.cpp
@@ -397,7 +397,17 @@ void LocalDirReadJob::processSubDir( const QString & entryName, DirInfo * subDir
     _dir->insertChild( subDir );
     childAdded( subDir );
 
-    if ( matchesExcludeRule( entryName ) )
+    // On macOS, /System/Volumes/Data is the APFS data volume that backs the
+    // firmlinks at /Users, /Applications, /Library, etc. Walking into it
+    // re-counts everything already read via the firmlinks. The existing
+    // mount-point / cross-filesystem logic doesn't catch this, so handle it
+    // explicitly here.
+    bool isMacFirmlinkOrigin = false;
+#ifdef Q_OS_MACOS
+    isMacFirmlinkOrigin = ( subDir->url() == "/System/Volumes/Data" );
+#endif
+
+    if ( matchesExcludeRule( entryName ) || isMacFirmlinkOrigin )
     {
 	subDir->setExcluded();
 	finishReading( subDir, DirOnRequestOnly );


### PR DESCRIPTION
This PR addresses this issue: https://github.com/jesusha123/qdirstat-macos/issues/10

## Summary

On modern macOS there are two separate mounts: a read-only one at /, and a writable one at /System/Volumes/Data that holds everything the user actually writes (/Users, /Applications, /Library, etc).

To keep the traditional paths working (/Users etc), macOS uses firmlinks, which are kernel level directory redirects. So /Users actually points into /System/Volumes/Data/Users. The same bytes are reachable via two paths.

When QDirStat scans / on macOS it reads all the user data through the firmlinks, and then also descends into /System/Volumes/Data and counts the same bytes a second time, roughly doubling the reported total. The mount point / cross filesystem logic in DirReadJob doesn't catch this (the firmlinked traversal never hits the mount point branch), so I'm hardcoding a skip for that one path in processSubDir(), guarded by Q_OS_MACOS. No effect on Linux.

There is precedent for this kind of exclusion in similar tools like GrandPerspective and SquirrelDisk.

## Testing

Compiled and tested locally. After the fix, /System/Volumes/Data folder is marked as excluded on qdirstat and no double counting is observed.