### PR TITLE
Add native macOS build support and fix menubar icons on Qt 6

### DIFF
--- a/doc/doc.pro
+++ b/doc/doc.pro
@@ -2,7 +2,7 @@
 
 isEmpty(INSTALL_PREFIX):INSTALL_PREFIX = /usr
 
-TEMPLATE   = app
+TEMPLATE   = aux
 TARGET     = $(nothing)
 doc.files  = *.txt *.md ../*.md
 

--- a/doc/stats/stats.pro
+++ b/doc/stats/stats.pro
@@ -2,7 +2,7 @@
 
 isEmpty(INSTALL_PREFIX):INSTALL_PREFIX = /usr
 
-TEMPLATE   = app
+TEMPLATE   = aux
 TARGET     = $(nothing)
 doc.files  = *.txt *.md
 

--- a/qdirstat.pro
+++ b/qdirstat.pro
@@ -31,15 +31,3 @@ SUBDIRS  = src scripts doc doc/stats man
 # Not used by default
 #
 # SUBDIRS += metainfo
-
-macx {
-    # FIXME: Prevent build failure because of missing main() (issue #131)
-    # This is a pretty radical approach, and you won't get any of the scripts
-    # or any of the documentation on MacOS X; but it works.
-    #
-    # If anybody with good MacOS X know-how has a better idea that is still
-    # robust enough to prevent that same build failure to reappear, please open
-    # a pull request.
-
-    SUBDIRS = src
-}

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build a self-contained qdirstat.app (and optional .dmg) on macOS.
+# Requires Homebrew: brew install qt qt5compat
+set -euo pipefail
+
+clean=0
+make_dmg=1
+for arg in "$@"; do
+    case "$arg" in
+        --clean)    clean=1 ;;
+        --no-dmg)   make_dmg=0 ;;
+        --dmg)      make_dmg=1 ;;
+        -h|--help)
+            sed -n '2,5p; /^for arg/,/^done/p' "$0"
+            exit 0 ;;
+        *) echo "unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+repo="$(cd "$(dirname "$0")/.." && pwd)"
+build="$repo/build"
+
+command -v qmake6      >/dev/null || { echo "qmake6 not found (brew install qt)" >&2; exit 1; }
+command -v macdeployqt6 >/dev/null || { echo "macdeployqt6 not found (brew install qt)" >&2; exit 1; }
+
+gettext_prefix="$(brew --prefix gettext 2>/dev/null || echo /opt/homebrew/opt/gettext)"
+[[ -f "$gettext_prefix/include/libintl.h" ]] || {
+    echo "libintl.h not found under $gettext_prefix (brew install gettext)" >&2
+    exit 1
+}
+
+if (( clean )) || [[ ! -f "$build/Makefile" ]]; then
+    rm -rf "$build"
+    mkdir -p "$build"
+    (cd "$build" && qmake6 "$repo/src/src.pro" \
+        "QT+=svg svgwidgets" \
+        "INCLUDEPATH+=$gettext_prefix/include" \
+        "LIBS+=-L$gettext_prefix/lib -lintl")
+fi
+
+(cd "$build" && make -j"$(sysctl -n hw.ncpu)")
+
+# Strip the qmake-baked /opt/homebrew/lib rpath BEFORE macdeployqt runs so the
+# bundled binary doesn't dual-load Qt on a developer machine. On a friend's Mac
+# this rpath would dead-end harmlessly, but on this machine it causes
+# duplicate-class warnings and possible spurious crashes.
+exe="$build/qdirstat.app/Contents/MacOS/qdirstat"
+if otool -l "$exe" | grep -q '/opt/homebrew/lib'; then
+    install_name_tool -delete_rpath /opt/homebrew/lib "$exe"
+fi
+
+deploy_args=( "$build/qdirstat.app" -verbose=2 )
+(( make_dmg )) && deploy_args+=( -dmg )
+macdeployqt6 "${deploy_args[@]}"
+
+echo
+echo "Built:  $build/qdirstat.app"
+(( make_dmg )) && echo "DMG:    $build/qdirstat.dmg"

--- a/scripts/scripts.pro
+++ b/scripts/scripts.pro
@@ -2,7 +2,7 @@
 
 isEmpty(INSTALL_PREFIX):INSTALL_PREFIX = /usr
 
-TEMPLATE       = app
+TEMPLATE       = aux
 TARGET         = $(nothing)
 QMAKE_STRIP    = /bin/true # prevent stripping the script(s)
 

--- a/src/FileSizeStatsWindow.cpp
+++ b/src/FileSizeStatsWindow.cpp
@@ -499,7 +499,11 @@ void FileSizeStatsWindow::showHelp()
 
     logInfo() << "Help topic: " << topic << endl;
     QString helpUrl = "https://github.com/shundhammer/qdirstat/blob/master/doc/stats/" + topic;
+#ifdef Q_OS_MAC
+    QString program = "/usr/bin/open";
+#else
     QString program = "/usr/bin/xdg-open";
+#endif
 
     logInfo() << "Starting  " << program << " " << helpUrl << endl;
     QProcess::startDetached( program, QStringList() << helpUrl );

--- a/src/MountPoints.cpp
+++ b/src/MountPoints.cpp
@@ -16,6 +16,11 @@
 #include "Logger.h"
 #include "Exception.h"
 
+#ifdef Q_OS_MAC
+#  include <sys/param.h>
+#  include <sys/mount.h>
+#endif
+
 #define LSBLK_TIMEOUT_SEC       10
 #define USE_PROC_MOUNTS         1
 
@@ -296,7 +301,9 @@ void MountPoints::ensurePopulated()
     if ( _isPopulated )
 	return;
 
-#if USE_PROC_MOUNTS
+#ifdef Q_OS_MAC
+    readGetmntinfo();
+#elif USE_PROC_MOUNTS
 
     read( "/proc/mounts" ) || read( "/etc/mtab" );
 
@@ -311,6 +318,27 @@ void MountPoints::ensurePopulated()
     _isPopulated = true; // don't try more than once
     // dumpNormalMountPoints();
 }
+
+
+#ifdef Q_OS_MAC
+bool MountPoints::readGetmntinfo()
+{
+    struct statfs * fs = nullptr;
+    int n = getmntinfo( &fs, MNT_NOWAIT );
+    findNtfsDevices();
+    for ( int i = 0; i < n; ++i )
+    {
+        QString opts = ( fs[i].f_flags & MNT_RDONLY ) ? "ro" : QString();
+        MountPoint * mp = new MountPoint( fs[i].f_mntfromname, fs[i].f_mntonname,
+                                          fs[i].f_fstypename, opts );
+        CHECK_NEW( mp );
+        postProcess( mp );
+        add( mp );
+    }
+    if ( n > 0 ) _isPopulated = true;
+    return _isPopulated;
+}
+#endif
 
 
 bool MountPoints::read( const QString & filename )

--- a/src/MountPoints.h
+++ b/src/MountPoints.h
@@ -296,6 +296,14 @@ namespace QDirStat
          **/
         bool readStorageInfo();
 
+#ifdef Q_OS_MAC
+        /**
+         * Read mount points via the BSD getmntinfo(3) syscall on macOS.
+         * Returns 'true' if any mount point was found.
+         **/
+        bool readGetmntinfo();
+#endif
+
         /**
          * Post-process a mount point and add it to the internal list and map.
          **/

--- a/src/SysUtil.cpp
+++ b/src/SysUtil.cpp
@@ -153,7 +153,11 @@ void SysUtil::openInBrowser( const QString & url )
 {
     logDebug() << "Opening URL " << url << endl;
 
+#ifdef Q_OS_MAC
+    QProcess::startDetached( "/usr/bin/open", QStringList() << url );
+#else
     QProcess::startDetached( "/usr/bin/xdg-open", QStringList() << url );
+#endif
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,6 +122,15 @@ int main( int argc, char *argv[] )
     QCoreApplication::setApplicationName ( "QDirStat" );
 
     QApplication qtApp( argc, argv);
+
+#ifdef Q_OS_MAC
+    // Qt 6's cocoa platform theme hardcodes ShowIconsInMenus=false on all
+    // pre-Tahoe macOS, and QApplication's ctor flips AA_DontShowIconsInMenus
+    // to match -- *after* any user-supplied value. Re-flip it here, AFTER
+    // construction, to restore the Qt 5 behavior of icons in the menubar.
+    QCoreApplication::setAttribute( Qt::AA_DontShowIconsInMenus, false );
+#endif
+
     QStringList argList = QCoreApplication::arguments();
     argList.removeFirst(); // Remove program name
     logQtEnv();


### PR DESCRIPTION
## Summary

Add support for qdirstat to build and run natively on macOS using Homebrew Qt 6, producing a portable `.app` / `.dmg`.

`scripts/build-macos.sh`: runs `qmake6` → `make` → `macdeployqt6 -dmg` against Homebrew Qt 6 (neither `qdirstat.pro` nor `src/src.pro`)

`src/main.cpp`: restore icons in the macOS menubar

Qt 6's cocoa platform theme (`qcocoatheme.mm`) hardcodes `QPlatformTheme::ShowIconsInMenus = false` for every macOS older than 26 (Tahoe). Qt 5's cocoa theme had no such case. 