### PR TITLE
Use SPDX license classifier everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the original KDirStat.
 
 Target Platforms: Linux, BSD, Unix-like systems; macOS
 
-License: GPL V2
+License: GPL-2.0-only
 
 Updated: 2026-01-18
 

--- a/doc/Contributing.md
+++ b/doc/Contributing.md
@@ -96,7 +96,7 @@ Misleading documentation is worse than no documentation at all.
 **Do not** copy 30+ lines of legalese bullshit into any source file. One line
 in the header like
 
-    License: GPL V2 - see file LICENSE
+    License: GPL-2.0-only - see file LICENSE
 
 is plenty. Seriously, what are those people thinking who put all that legalese
 into source files? Sure, they listened to spineless corporate lawyers who just

--- a/screenshots/Screenshots.md
+++ b/screenshots/Screenshots.md
@@ -6,7 +6,7 @@ Qt-based directory statistics: KDirStat without any KDE -- from the original KDi
 
 Target Platforms: Linux, BSD, Unix-like systems
 
-License: GPL V2
+License: GPL-2.0-only
 
 
 ## QDirStat Main Window

--- a/scripts/pkg-tools/cache-exclude
+++ b/scripts/pkg-tools/cache-exclude
@@ -3,7 +3,7 @@
 # cache-exclude - script to filter out a list of files from a cache file.
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 #
 
 use strict;

--- a/scripts/pkg-tools/cache-kill-empty-dirs
+++ b/scripts/pkg-tools/cache-kill-empty-dirs
@@ -4,7 +4,7 @@
 # file
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 #
 
 use strict;

--- a/scripts/pkg-tools/complete-filelist-dpkg
+++ b/scripts/pkg-tools/complete-filelist-dpkg
@@ -4,7 +4,7 @@
 # dpkg version
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 
 
 SCRIPT_NAME=$(basename $0)

--- a/scripts/pkg-tools/complete-filelist-pacman
+++ b/scripts/pkg-tools/complete-filelist-pacman
@@ -4,7 +4,7 @@
 # rpm version
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 
 
 SCRIPT_NAME=$(basename $0)

--- a/scripts/pkg-tools/complete-filelist-rpm
+++ b/scripts/pkg-tools/complete-filelist-rpm
@@ -4,7 +4,7 @@
 # rpm version
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 
 
 SCRIPT_NAME=$(basename $0)

--- a/scripts/pkg-tools/show-unpkg-files
+++ b/scripts/pkg-tools/show-unpkg-files
@@ -3,7 +3,7 @@
 # Show unpackaged files in the root filesystem in QDirStat
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 #
 
 SCRIPT_NAME=$(basename $0)

--- a/scripts/pkg-tools/which-pkg-manager
+++ b/scripts/pkg-tools/which-pkg-manager
@@ -4,7 +4,7 @@
 # Currently supported: dpkg, rpm, pacman
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 #
 
 RPM=/bin/rpm

--- a/scripts/shadowed/unshadow-mount-points
+++ b/scripts/shadowed/unshadow-mount-points
@@ -6,7 +6,7 @@
 # https://github.com/shundhammer/qdirstat/blob/master/doc/Shadowed-by-Mount.md
 #
 # Author:  Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
-# License: GPL V2
+# License: GPL-2.0-only
 #
 
 SCRIPT_NAME=$(basename $0)

--- a/src/ActionManager.cpp
+++ b/src/ActionManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ActionManager.h
  *   Summary:	Common access to QActions defined in a .ui file
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ActionManager.h
+++ b/src/ActionManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ActionManager.h
  *   Summary:	Common access to QActions defined in a .ui file
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/AdaptiveTimer.cpp
+++ b/src/AdaptiveTimer.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: AdaptiveTimer.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/AdaptiveTimer.h
+++ b/src/AdaptiveTimer.h
@@ -1,7 +1,7 @@
 /*
  *   File name: AdaptiveTimer.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Attic.cpp
+++ b/src/Attic.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Attic.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Attic.h
+++ b/src/Attic.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Attic.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BookmarksManager.cpp
+++ b/src/BookmarksManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: BookmarksManager.cpp
  *   Summary:	Bookmarks Manager for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BookmarksManager.h
+++ b/src/BookmarksManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: BookmarksManager.h
  *   Summary:	Bookmarks Manager for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BreadcrumbNavigator.cpp
+++ b/src/BreadcrumbNavigator.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: BreadcrumbNavigator.cpp
  *   Summary:	Breadcrumb widget for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BreadcrumbNavigator.h
+++ b/src/BreadcrumbNavigator.h
@@ -1,7 +1,7 @@
 /*
  *   File name: BreadcrumbNavigator.h
  *   Summary:	Breadcrumb widget for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BrokenLibc.h
+++ b/src/BrokenLibc.h
@@ -1,7 +1,7 @@
 /*
  *   File name: BrokenLibc.h
  *   Summary:	Substitutes for common system-level defines
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BucketsTableModel.cpp
+++ b/src/BucketsTableModel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: BucketsTableModel.h
  *   Summary:	Data model for buckets table
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BucketsTableModel.h
+++ b/src/BucketsTableModel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: BucketsTableModel.h
  *   Summary:	Data model for buckets table
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BusyPopup.cpp
+++ b/src/BusyPopup.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: BusyPopup.cpp
  *   Summary:	QDirStat generic widget classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/BusyPopup.h
+++ b/src/BusyPopup.h
@@ -1,7 +1,7 @@
 /*
  *   File name: BusyPopup.h
  *   Summary:	QDirStat generic widget classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Cleanup.cpp
+++ b/src/Cleanup.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Cleanup.cpp
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Cleanup.h
+++ b/src/Cleanup.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Cleanup.h
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/CleanupCollection.cpp
+++ b/src/CleanupCollection.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: CleanupCollection.cpp
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/CleanupCollection.h
+++ b/src/CleanupCollection.h
@@ -1,7 +1,7 @@
 /*
  *   File name:	CleanupCollection.h
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/CleanupConfigPage.cpp
+++ b/src/CleanupConfigPage.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: CleanupConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/CleanupConfigPage.h
+++ b/src/CleanupConfigPage.h
@@ -1,7 +1,7 @@
 /*
  *   File name: CleanupConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ConfigDialog.cpp
+++ b/src/ConfigDialog.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ConfigDialog.cpp
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ConfigDialog.h
+++ b/src/ConfigDialog.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ConfigDialog.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DataColumns.cpp
+++ b/src/DataColumns.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DataColumns.cpp
  *   Summary:	Data column mapping
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DataColumns.h
+++ b/src/DataColumns.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DataColumns.h
  *   Summary:	Data column mapping
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DebugHelpers.cpp
+++ b/src/DebugHelpers.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DebugHelpers.cpp
  *   Summary:	Debugging helper functions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DebugHelpers.h
+++ b/src/DebugHelpers.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DebugHelpers.h
  *   Summary:	Debugging helper functions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DelayedRebuilder.cpp
+++ b/src/DelayedRebuilder.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DelayedRebuilder.cpp
  *   Summary:	Utility class to handle delayed rebuilding of widgets
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DelayedRebuilder.h
+++ b/src/DelayedRebuilder.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DelayedRebuilder.h
  *   Summary:	Utility class to handle delayed rebuilding of widgets
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirInfo.cpp
+++ b/src/DirInfo.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirInfo.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirInfo.h
+++ b/src/DirInfo.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirInfo.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirReadJob.cpp
+++ b/src/DirReadJob.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirReadJob.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirReadJob.h
+++ b/src/DirReadJob.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirReadJob.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirSaver.cpp
+++ b/src/DirSaver.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name:	DirSaver.cpp
  *   Summary:	Utility object to save current working directory
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirSaver.h
+++ b/src/DirSaver.h
@@ -1,7 +1,7 @@
 /*
  *   File name:	DirSaver.h
  *   Summary:	Utility object to save current working directory
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTree.cpp
+++ b/src/DirTree.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTree.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTree.h
+++ b/src/DirTree.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTree.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeCache.cpp
+++ b/src/DirTreeCache.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeCache.cpp
  *   Summary:	QDirStat cache reader / writer
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeCache.h
+++ b/src/DirTreeCache.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeCache.h
  *   Summary:	QDirStat cache reader / writer
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeFilter.h
+++ b/src/DirTreeFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeFilter.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeModel.cpp
+++ b/src/DirTreeModel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeModel.cpp
  *   Summary:	Qt data model for directory tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeModel.h
+++ b/src/DirTreeModel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeModel.h
  *   Summary:	Qt data model for directory tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreePatternFilter.cpp
+++ b/src/DirTreePatternFilter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreePatternFilter.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreePatternFilter.h
+++ b/src/DirTreePatternFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreePatternFilter.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreePkgFilter.cpp
+++ b/src/DirTreePkgFilter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreePkgFilter.cpp
  *   Summary:	Package manager support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreePkgFilter.h
+++ b/src/DirTreePkgFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreePkgFilter.h
  *   Summary:	Package manager support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeView.cpp
+++ b/src/DirTreeView.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeView.cpp
  *   Summary:	Tree view widget for directory tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DirTreeView.h
+++ b/src/DirTreeView.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DirTreeView.h
  *   Summary:	Tree view widget for directory tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DiscoverActions.cpp
+++ b/src/DiscoverActions.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DiscoverActions.cpp
  *   Summary:	Actions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DiscoverActions.h
+++ b/src/DiscoverActions.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DiscoverActions.h
  *   Summary:	Actions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DotEntry.cpp
+++ b/src/DotEntry.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DotEntry.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DotEntry.h
+++ b/src/DotEntry.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DotEntry.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DpkgPkgManager.cpp
+++ b/src/DpkgPkgManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: DpkgPkgManager.cpp
  *   Summary:	Dpkg package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/DpkgPkgManager.h
+++ b/src/DpkgPkgManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: DPkgPkgManager.cpp
  *   Summary:	Dpkg package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Exception.cpp
  *   Summary:	Exception classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Exception.h
  *   Summary:	Exception classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExcludeRules.cpp
+++ b/src/ExcludeRules.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name:	ExcludeRules.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExcludeRules.h
+++ b/src/ExcludeRules.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ExcludeRules.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExcludeRulesConfigPage.cpp
+++ b/src/ExcludeRulesConfigPage.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ExcludeRulesConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExcludeRulesConfigPage.h
+++ b/src/ExcludeRulesConfigPage.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ExcludeRulesConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExistingDirCompleter.cpp
+++ b/src/ExistingDirCompleter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ExistingDirCompleter.h
  *   Summary:	QDirStat widget support classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExistingDirCompleter.h
+++ b/src/ExistingDirCompleter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ExistingDirCompleter.h
  *   Summary:	QDirStat widget support classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExistingDirValidator.cpp
+++ b/src/ExistingDirValidator.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ExistingDirValidator.h
  *   Summary:	QDirStat widget support classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ExistingDirValidator.h
+++ b/src/ExistingDirValidator.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ExistingDirValidator.h
  *   Summary:	QDirStat widget support classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileAgeStats.cpp
+++ b/src/FileAgeStats.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileAgeStats.cpp
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileAgeStats.h
+++ b/src/FileAgeStats.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileAgeStats.h
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileAgeStatsWindow.cpp
+++ b/src/FileAgeStatsWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileAgeStatsWindow.h
  *   Summary:	QDirStat "File Age Statistics" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileAgeStatsWindow.h
+++ b/src/FileAgeStatsWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileAgeStatsWindow.h
  *   Summary:	QDirStat "File Age Statistics" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileDetailsView.cpp
+++ b/src/FileDetailsView.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileDetailsView.h
  *   Summary:	Details view for the currently selected file or directory
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileDetailsView.h
+++ b/src/FileDetailsView.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileDetailsView.h
  *   Summary:	Details view for the currently selected file or directory
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfo.cpp
+++ b/src/FileInfo.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfo.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfo.h
+++ b/src/FileInfo.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfo.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoIterator.cpp
+++ b/src/FileInfoIterator.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoIterator.cpp
  *   Summary:	Support classes for QDirStat - DirTree iterator classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoIterator.h
+++ b/src/FileInfoIterator.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoIterator.h
  *   Summary:	Support classes for QDirStat - DirTree iterators
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoSet.cpp
+++ b/src/FileInfoSet.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoSet.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoSet.h
+++ b/src/FileInfoSet.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoSet.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoSorter.cpp
+++ b/src/FileInfoSorter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoSorter.cpp
  *   Summary:	Functor to handle sorting FileInfo objects
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileInfoSorter.h
+++ b/src/FileInfoSorter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileInfoSorter.h
  *   Summary:	Functor to handle sorting FileInfo objects
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileMTimeStats.cpp
+++ b/src/FileMTimeStats.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileMTimeStats.cpp
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileMTimeStats.h
+++ b/src/FileMTimeStats.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileMTimeStats.h
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSearchFilter.cpp
+++ b/src/FileSearchFilter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSearchFilter.h
  *   Summary:	Package manager Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSearchFilter.h
+++ b/src/FileSearchFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSearchFilter.h
  *   Summary:	Package manager Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSize.h
+++ b/src/FileSize.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSize.h
  *   Summary:	Basic typedefs for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeLabel.cpp
+++ b/src/FileSizeLabel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeLabel.cpp
  *   Summary:	Specialized QLabel for a file size for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeLabel.h
+++ b/src/FileSizeLabel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeLabel.h
  *   Summary:	Specialized QLabel for a file size for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeStats.cpp
+++ b/src/FileSizeStats.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeStats.cpp
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeStats.h
+++ b/src/FileSizeStats.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeStats.h
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeStatsWindow.cpp
+++ b/src/FileSizeStatsWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeStatsWindow.cpp
  *   Summary:	QDirStat size type statistics window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileSizeStatsWindow.h
+++ b/src/FileSizeStatsWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileSizeStatsWindow.h
  *   Summary:	QDirStat file size statistics window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileTypeStats.cpp
+++ b/src/FileTypeStats.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileTypeStats.cpp
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileTypeStats.h
+++ b/src/FileTypeStats.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileTypeStats.h
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileTypeStatsWindow.cpp
+++ b/src/FileTypeStatsWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FileTypeStatsWindow.cpp
  *   Summary:	QDirStat file type statistics window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FileTypeStatsWindow.h
+++ b/src/FileTypeStatsWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FileTypeStatsWindow.h
  *   Summary:	QDirStat file type statistics window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FilesystemsWindow.cpp
+++ b/src/FilesystemsWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FilesystemsWindow.cpp
  *   Summary:	QDirStat "Mounted Filesystems" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FilesystemsWindow.h
+++ b/src/FilesystemsWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FilesystemsWindow.h
  *   Summary:	QDirStat "Mounted Filesystems" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FindFilesDialog.cpp
+++ b/src/FindFilesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FindFilesDialog.cpp
  *   Summary:	QDirStat "Find Files" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FindFilesDialog.h
+++ b/src/FindFilesDialog.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FindFilesDialog.h
  *   Summary:	QDirStat "Find Files" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FormatUtil.cpp
+++ b/src/FormatUtil.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: FormatUtil.cpp
  *   Summary:	String formatting utilities for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/FormatUtil.h
+++ b/src/FormatUtil.h
@@ -1,7 +1,7 @@
 /*
  *   File name: FormatUtil.h
  *   Summary:	String formatting utilities for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/GeneralConfigPage.cpp
+++ b/src/GeneralConfigPage.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: GeneralConfigPage.cpp
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/GeneralConfigPage.h
+++ b/src/GeneralConfigPage.h
@@ -1,7 +1,7 @@
 /*
  *   File name: GeneralConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HeaderTweaker.cpp
+++ b/src/HeaderTweaker.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HeaderTweaker.cpp
  *   Summary:	Helper class for DirTreeView
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HeaderTweaker.h
+++ b/src/HeaderTweaker.h
@@ -1,7 +1,7 @@
 /*
  *   File name: HeaderTweaker.h
  *   Summary:	Helper class for DirTreeView
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramDraw.cpp
+++ b/src/HistogramDraw.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramDraw.cpp
  *   Summary:	Draw routines for file size histogram
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramItems.cpp
+++ b/src/HistogramItems.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramViewItems.cpp
  *   Summary:	QGraphicsItems for file size histogram for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramItems.h
+++ b/src/HistogramItems.h
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramView.h
  *   Summary:	View widget for histogram rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramOverflowPanel.cpp
+++ b/src/HistogramOverflowPanel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramOverflowPanel.cpp
  *   Summary:	Overflow panel drawing for file size histogram
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramView.cpp
+++ b/src/HistogramView.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramView.cpp
  *   Summary:	View widget for histogram rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistogramView.h
+++ b/src/HistogramView.h
@@ -1,7 +1,7 @@
 /*
  *   File name: HistogramView.h
  *   Summary:	View widget for histogram rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/History.cpp
+++ b/src/History.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: History.cpp
  *   Summary:	Directory navigation history for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/History.h
+++ b/src/History.h
@@ -1,7 +1,7 @@
 /*
  *   File name: History.h
  *   Summary:	Directory navigation history for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistoryButtons.cpp
+++ b/src/HistoryButtons.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: HistoryButtons.cpp
  *   Summary:	History buttons handling for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/HistoryButtons.h
+++ b/src/HistoryButtons.h
@@ -1,7 +1,7 @@
 /*
  *   File name: HistoryButtons.h
  *   Summary:	History buttons handling for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ListEditor.cpp
+++ b/src/ListEditor.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ListEditor.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ListEditor.h
+++ b/src/ListEditor.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ListEditor.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LocateFileTypeWindow.cpp
+++ b/src/LocateFileTypeWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: LocateFileTypeWindow.cpp
  *   Summary:	QDirStat "locate files by type" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LocateFileTypeWindow.h
+++ b/src/LocateFileTypeWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: LocateFileTypeWindow.h
  *   Summary:	QDirStat "locate files by type" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LocateFilesWindow.cpp
+++ b/src/LocateFilesWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: LocateFilesWindow.cpp
  *   Summary:	QDirStat "locate files" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LocateFilesWindow.h
+++ b/src/LocateFilesWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: LocateFilesWindow.h
  *   Summary:	QDirStat "locate files" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LogStream.cpp
+++ b/src/LogStream.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: LogStream.cpp
  *   Summary:   Logger helper class for QDirStat
- *   License:   GPL V2 - See file LICENSE for details.
+ *   License:   GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:    Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/LogStream.h
+++ b/src/LogStream.h
@@ -1,7 +1,7 @@
 /*
  *   File name: LogStream.h
  *   Summary:   Logger helper class for QDirStat
- *   License:   GPL V2 - See file LICENSE for details.
+ *   License:   GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:    Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Logger.cpp
  *   Summary:   Logger class for QDirStat
- *   License:   GPL V2 - See file LICENSE for details.
+ *   License:   GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:    Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Logger.h
  *   Summary:   Logger class for QDirStat
- *   License:   GPL V2 - See file LICENSE for details.
+ *   License:   GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:    Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindow.cpp
  *   Summary:	QDirStat main window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindow.h
  *   Summary:	QDirStat main window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MainWindowHelp.cpp
+++ b/src/MainWindowHelp.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindowHelp.cpp
  *   Summary:	Help menu actions in the QDirStat main window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */
@@ -32,7 +32,7 @@ void MainWindow::showAboutDialog()
     text += tr( "Contact: " ) + QString( "<a href=\"mailto:%1\">%2</a>" ).arg( mailTo ).arg( mailTo );
     text += "</p><p>";
     text += QString( "<p><a href=\"%1\">%2</a></p>" ).arg( homePage ).arg( homePage );
-    text += tr( "License: GPL V2 (GNU General Public License Version 2)" );
+    text += tr( "License: GPL-2.0-only (GNU General Public License Version 2)" );
     text += "</p><p>";
     text += tr( "This is free Open Source software, provided to you hoping that it might be "
 		"useful for you. It does not cost you anything, but on the other hand there "

--- a/src/MainWindowLayout.cpp
+++ b/src/MainWindowLayout.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindowLayout.cpp
  *   Summary:	QDirStat main window layout-related functions
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MainWindowMenus.cpp
+++ b/src/MainWindowMenus.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindowMenus.cpp
  *   Summary:	Connecting menu actions in the QDirStat main window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MainWindowUnpkg.cpp
+++ b/src/MainWindowUnpkg.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MainWindowLayout.cpp
  *   Summary:	Unpackaged files view functions in the QDirStat main window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MessagePanel.cpp
+++ b/src/MessagePanel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MessagePanel.cpp
  *   Summary:	Container widget for PanelMessages
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MessagePanel.h
+++ b/src/MessagePanel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MessagePanel.h
  *   Summary:	Container widget for PanelMessages
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategorizer.cpp
+++ b/src/MimeCategorizer.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategorizer.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategorizer.h
+++ b/src/MimeCategorizer.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategorizer.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategory.cpp
+++ b/src/MimeCategory.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategory.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategory.h
+++ b/src/MimeCategory.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategory.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategoryConfigPage.cpp
+++ b/src/MimeCategoryConfigPage.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategoryConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MimeCategoryConfigPage.h
+++ b/src/MimeCategoryConfigPage.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MimeCategoryConfigPage.h
  *   Summary:	QDirStat configuration dialog classes
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MountPoints.cpp
+++ b/src/MountPoints.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: MountPoints.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/MountPoints.h
+++ b/src/MountPoints.h
@@ -1,7 +1,7 @@
 /*
  *   File name: MountPoints.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OpenDirDialog.cpp
+++ b/src/OpenDirDialog.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: OpenDirDialog.cpp
  *   Summary:	QDirStat "open directory" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OpenDirDialog.h
+++ b/src/OpenDirDialog.h
@@ -1,7 +1,7 @@
 /*
  *   File name: OpenDirDialog.h
  *   Summary:	QDirStat "open directory" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OpenPkgDialog.cpp
+++ b/src/OpenPkgDialog.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: OpenPkgDialog.cpp
  *   Summary:	QDirStat "open installed packages" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OpenPkgDialog.h
+++ b/src/OpenPkgDialog.h
@@ -1,7 +1,7 @@
 /*
  *   File name: OpenPkgDialog.h
  *   Summary:	QDirStat "open installed packages" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OutputWindow.cpp
+++ b/src/OutputWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: OutputWindow.cpp
  *   Summary:	Terminal-like window to watch output of an external process
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/OutputWindow.h
+++ b/src/OutputWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: OutputWindow.h
  *   Summary:	Terminal-like window to watch output of an external process
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PacManPkgManager.cpp
+++ b/src/PacManPkgManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PacManPkgManager.cpp
  *   Summary:	Simple package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PacManPkgManager.h
+++ b/src/PacManPkgManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PacManPkgManager.h
  *   Summary:	PacMan package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PanelMessage.cpp
+++ b/src/PanelMessage.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PanelMessage.cpp
  *   Summary:	Message in a panel with icon and close button
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PanelMessage.h
+++ b/src/PanelMessage.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PanelMessage.h
  *   Summary:	Message in a panel with icon and close button
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PathSelector.cpp
+++ b/src/PathSelector.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PathSelector.cpp
  *   Summary:	Path selection list widget for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PathSelector.h
+++ b/src/PathSelector.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PathSelector.h
  *   Summary:	Path selection list widget for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PercentBar.cpp
+++ b/src/PercentBar.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PercentBar.cpp
  *   Summary:	Functions and item delegate for percent bar
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PercentBar.h
+++ b/src/PercentBar.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PercentBar.h
  *   Summary:	Functions and item delegate for percent bar
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PercentileStats.cpp
+++ b/src/PercentileStats.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PercentileStats.cpp
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PercentileStats.h
+++ b/src/PercentileStats.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PercentileStats.h
  *   Summary:	Statistics classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgFileListCache.cpp
+++ b/src/PkgFileListCache.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgFileListCache.cpp
  *   Summary:	Package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgFileListCache.h
+++ b/src/PkgFileListCache.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgFileListCache.h
  *   Summary:	Package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgFilter.cpp
+++ b/src/PkgFilter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgFilter.h
  *   Summary:	Package manager Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgFilter.h
+++ b/src/PkgFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgFilter.h
  *   Summary:	Package manager Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgInfo.cpp
+++ b/src/PkgInfo.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgInfo.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgInfo.h
+++ b/src/PkgInfo.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgInfo.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgManager.cpp
+++ b/src/PkgManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgManager.cpp
  *   Summary:	Package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgManager.h
+++ b/src/PkgManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgManager.h
  *   Summary:	Package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgQuery.cpp
+++ b/src/PkgQuery.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgManager.cpp
  *   Summary:	Simple package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgQuery.h
+++ b/src/PkgQuery.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgQuery.h
  *   Summary:	Package manager query support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgReader.cpp
+++ b/src/PkgReader.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgReader.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PkgReader.h
+++ b/src/PkgReader.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PkgReader.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PopupLabel.cpp
+++ b/src/PopupLabel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: PopupLabel.cpp
  *   Summary:	QLabel with a pop-up
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/PopupLabel.h
+++ b/src/PopupLabel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: PopupLabel.h
  *   Summary:	QLabel with a pop-up
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ProcessStarter.cpp
+++ b/src/ProcessStarter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ProcessStarter.h
  *   Summary:	Utilities for external processes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ProcessStarter.h
+++ b/src/ProcessStarter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ProcessStarter.h
  *   Summary:	Utilities for external processes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/QDirStatApp.cpp
+++ b/src/QDirStatApp.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: QDirStatApp.cpp
  *   Summary:	QDirStat application class for key objects
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/QDirStatApp.h
+++ b/src/QDirStatApp.h
@@ -1,7 +1,7 @@
 /*
  *   File name: QDirStatApp.h
  *   Summary:	QDirStat application class for key objects
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Refresher.cpp
+++ b/src/Refresher.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Refresher.h
  *   Summary:	Helper class to refresh a number of subtrees
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Refresher.h
+++ b/src/Refresher.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Refresher.h
  *   Summary:	Helper class to refresh a number of subtrees
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/RpmPkgManager.cpp
+++ b/src/RpmPkgManager.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: RpmPkgManager.cpp
  *   Summary:	RPM package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/RpmPkgManager.h
+++ b/src/RpmPkgManager.h
@@ -1,7 +1,7 @@
 /*
  *   File name: RpmPkgManager.h
  *   Summary:	RPM package manager support for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SearchFilter.cpp
+++ b/src/SearchFilter.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SearchFilter.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SearchFilter.h
+++ b/src/SearchFilter.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SearchFilter.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SelectionModel.cpp
+++ b/src/SelectionModel.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SelectionModel.cpp
  *   Summary:	Handling of selected items
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SelectionModel.h
+++ b/src/SelectionModel.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SelectionModel.h
  *   Summary:	Handling of selected items
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Settings.cpp
  *   Summary:	Specialized settings classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Settings.h
  *   Summary:	Specialized settings classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SettingsHelpers.cpp
+++ b/src/SettingsHelpers.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SettingsHelpers.cpp
  *   Summary:	Helper functions for QSettings for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SettingsHelpers.h
+++ b/src/SettingsHelpers.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SettingsHelpers.h
  *   Summary:	Helper functions for QSettings for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ShowUnpkgFilesDialog.cpp
+++ b/src/ShowUnpkgFilesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: ShowUnpkgFilesDialog.cpp
  *   Summary:	QDirStat "show unpackaged files" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/ShowUnpkgFilesDialog.h
+++ b/src/ShowUnpkgFilesDialog.h
@@ -1,7 +1,7 @@
 /*
  *   File name: ShowUnpkgFilesDialog.h
  *   Summary:	QDirStat "show unpackaged files" dialog
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SignalBlocker.h
+++ b/src/SignalBlocker.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SignalBlocker.h
  *   Summary:	Helper class to block undesired Qt signals
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SizeColDelegate.cpp
+++ b/src/SizeColDelegate.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SizeColDelegate.cpp
  *   Summary:	DirTreeView delegate for the size column
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SizeColDelegate.h
+++ b/src/SizeColDelegate.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SizeColDelegate.h
  *   Summary:	DirTreeView delegate for the size column
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/StdCleanup.cpp
+++ b/src/StdCleanup.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: StdCleanup.cpp
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/StdCleanup.h
+++ b/src/StdCleanup.h
@@ -1,7 +1,7 @@
 /*
  *   File name: StdCleanup.h
  *   Summary:	QDirStat classes to reclaim disk space
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Subtree.cpp
+++ b/src/Subtree.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Subtree.cpp
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Subtree.h
+++ b/src/Subtree.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Subtree.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SysUtil.cpp
+++ b/src/SysUtil.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SysUtil.cpp
  *   Summary:	System utility functions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SysUtil.h
+++ b/src/SysUtil.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SysUtil.h
  *   Summary:	System utility functions for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SystemFileChecker.cpp
+++ b/src/SystemFileChecker.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: SystemFileChecker.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/SystemFileChecker.h
+++ b/src/SystemFileChecker.h
@@ -1,7 +1,7 @@
 /*
  *   File name: SystemFileChecker.h
  *   Summary:	Support classes for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Translator.cpp
+++ b/src/Translator.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Translator.cpp
  *   Summary:	Helper class for user message translations
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  *              Donated by the Myrlyn project

--- a/src/Translator.h
+++ b/src/Translator.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Translator.h
  *   Summary:	Helper class for user message translations
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  *              Donated by the Myrlyn project

--- a/src/Trash.cpp
+++ b/src/Trash.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: Trash.h
  *   Summary:	Implementation of the XDG Trash spec for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Trash.h
+++ b/src/Trash.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Trash.h
  *   Summary:	Implementation of the XDG Trash spec for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreeWalker.cpp
+++ b/src/TreeWalker.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: TreeWalker.cpp
  *   Summary:	QDirStat helper class to walk a FileInfo tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreeWalker.h
+++ b/src/TreeWalker.h
@@ -1,7 +1,7 @@
 /*
  *   File name: TreeWalker.h
  *   Summary:	QDirStat helper class to walk a FileInfo tree
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreemapTile.cpp
+++ b/src/TreemapTile.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: TreemapTile.cpp
  *   Summary:	Treemap rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreemapTile.h
+++ b/src/TreemapTile.h
@@ -1,7 +1,7 @@
 /*
  *   File name: TreemapTile.h
  *   Summary:	Treemap rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreemapView.cpp
+++ b/src/TreemapView.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: TreemapView.cpp
  *   Summary:	View widget for treemap rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/TreemapView.h
+++ b/src/TreemapView.h
@@ -1,7 +1,7 @@
 /*
  *   File name: TreemapView.h
  *   Summary:	View widget for treemap rendering for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/UnpkgSettings.cpp
+++ b/src/UnpkgSettings.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: UnpkgSettings.cpp
  *   Summary:	Parameters for "unpackaged files" view
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/UnpkgSettings.h
+++ b/src/UnpkgSettings.h
@@ -1,7 +1,7 @@
 /*
  *   File name: UnpkgSettings.h
  *   Summary:	Parameters for "unpackaged files" view
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/UnreadableDirsWindow.cpp
+++ b/src/UnreadableDirsWindow.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: UnreadableDirsWindow.cpp
  *   Summary:	QDirStat file type statistics window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/UnreadableDirsWindow.h
+++ b/src/UnreadableDirsWindow.h
@@ -1,7 +1,7 @@
 /*
  *   File name: UnreadableDirsWindow.h
  *   Summary:	QDirStat "locate files" window
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,7 +1,7 @@
 /*
  *   File name: Version.h
  *   Summary:	Version number header for QDirStat
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 /*
  *   File name: main.cpp
  *   Summary:	QDirStat main program
- *   License:	GPL V2 - See file LICENSE for details.
+ *   License:	GPL-2.0-only - See file LICENSE for details.
  *
  *   Author:	Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
  */

--- a/test/util/create-files
+++ b/test/util/create-files
@@ -4,7 +4,7 @@
 #
 # (c) 2019 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
 #
-# License: GPL V2
+# License: GPL-2.0-only
 
 
 SCRIPT_NAME=$(basename $0)


### PR DESCRIPTION
Simple sed for `GPL V2` into `GPL-2.0-only`.

The SPDX `GPL-2.0-only` was already used in a couple files, this PR unifies it everywhere.