### PR TITLE
Fix opening URLs on macOS (use open, not xdg-open)

### DIFF
--- a/src/FileSizeStatsWindow.cpp
+++ b/src/FileSizeStatsWindow.cpp
@@ -10,7 +10,6 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QCommandLinkButton>
-#include <QProcess>
 
 #include "FileSizeStatsWindow.h"
 #include "HistogramView.h"
@@ -21,6 +20,7 @@
 #include "HeaderTweaker.h"
 #include "QDirStatApp.h"
 #include "FormatUtil.h"
+#include "SysUtil.h"
 #include "Logger.h"
 #include "Exception.h"
 
@@ -499,8 +499,6 @@ void FileSizeStatsWindow::showHelp()
 
     logInfo() << "Help topic: " << topic << endl;
     QString helpUrl = "https://github.com/shundhammer/qdirstat/blob/master/doc/stats/" + topic;
-    QString program = "/usr/bin/xdg-open";
 
-    logInfo() << "Starting  " << program << " " << helpUrl << endl;
-    QProcess::startDetached( program, QStringList() << helpUrl );
+    SysUtil::openInBrowser( helpUrl );
 }

--- a/src/SysUtil.cpp
+++ b/src/SysUtil.cpp
@@ -24,6 +24,13 @@
 #include "Exception.h"
 
 
+#ifdef Q_OS_MAC
+#  define OPEN_CMD "/usr/bin/open"
+#else
+#  define OPEN_CMD "/usr/bin/xdg-open"
+#endif
+
+
 using namespace QDirStat;
 
 
@@ -153,7 +160,7 @@ void SysUtil::openInBrowser( const QString & url )
 {
     logDebug() << "Opening URL " << url << endl;
 
-    QProcess::startDetached( "/usr/bin/xdg-open", QStringList() << url );
+    QProcess::startDetached( OPEN_CMD, QStringList() << url );
 }
 
 

--- a/src/SysUtil.h
+++ b/src/SysUtil.h
@@ -114,7 +114,8 @@ namespace QDirStat
 
 	/**
 	 * Open a URL in the desktop's default browser (using the
-	 * /usr/bin/xdg-open command).
+	 * /usr/bin/xdg-open command on Linux and other Unix systems,
+	 * /usr/bin/open on macOS).
 	 **/
 	void openInBrowser( const QString & url );
 


### PR DESCRIPTION
## Problem

On macOS, every Help menu entry that opens a documentation URL (Help, Treemap Help, What's New, Problems and Solutions, the pkg/unpkg view help, etc.) silently does nothing. The same applies to the help buttons in the File Size Statistics window. Only "Donate..." works, because it opens a dialog instead of a browser.

The log shows the actions do fire — `SysUtil::openInBrowser()` logs `Opening URL https://...` — but the URL never opens: the function runs `/usr/bin/xdg-open`, which does not exist on macOS, and `QProcess::startDetached()` fails silently. This affects the macOS builds packaged at [jesusha123/qdirstat-macos](https://github.com/jesusha123/qdirstat-macos) (currently building cb014eb with Qt 6.11.1), where users hit exactly this.

## Fix

- `SysUtil::openInBrowser()` now uses `/usr/bin/open` on macOS (`Q_OS_MAC`) and keeps `/usr/bin/xdg-open` everywhere else.
- `FileSizeStatsWindow::showHelp()` had its own copy of the xdg-open call; it now routes through `SysUtil::openInBrowser()` so the platform logic lives in one place.

The remaining `xdg-open` occurrences in `Cleanup.cpp` are inside the `$XDG_CURRENT_DESKTOP` desktop-detection branches (Linux-only at runtime), and the `fallbackApps()` macOS branch already uses `open`, so those are untouched.

## Testing

Built and run on macOS 26.5 (arm64, Qt 6.11.1) from this branch. Clicking Help > QDirStat Help now actually opens `README.md` in the default browser; before the change the exact same click logged `Opening URL https://...` and did nothing at all, because `xdg-open` does not exist on macOS. No behavior change on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dt54uZv1qEPqMRSruxRL4
